### PR TITLE
Add preserve content filenames option for CSV

### DIFF
--- a/example_tsv_config.ini
+++ b/example_tsv_config.ini
@@ -33,8 +33,11 @@ class = CsvSingleFile
 output_directory = "/tmp/mik_csv_output"
 ; By default, metadata and content files are overwritten if they exist.
 ; These settings will preserve the files and log that they already exist.
+; Content files are not overwritten if input and output directories match
+; and filenames are preserved (in other words: generate metadata only).
 ; overwrite_metadata_files = false
 ; overwrite_content_files = false
+preserve_content_filenames = false
 
 [MANIPULATORS]
 ; One or more filemanipulators classes.

--- a/extras/samples/example_tsv_config.ini
+++ b/extras/samples/example_tsv_config.ini
@@ -33,8 +33,11 @@ class = CsvSingleFile
 output_directory = "/tmp/mik_csv_output"
 ; By default, metadata and content files are overwritten if they exist.
 ; These settings will preserve the files and log that they already exist.
+; Content files are not overwritten if input and output directories match
+; and filenames are preserved (in other words: generate metadata only).
 ; overwrite_metadata_files = false
 ; overwrite_content_files = false
+preserve_content_filenames = false
 
 [MANIPULATORS]
 ; One or more filemanipulators classes.


### PR DESCRIPTION
This provides the option to retain the source filename for the
metadata and copied content. It also means that if the input
and output directories match (and filenames are preserved) then
it will act in metadata only mode i.e. no copying of content
will take place which will speed things up for large batches.