### PR TITLE
Issue 175

### DIFF
--- a/src/writers/CdmNewspapers.php
+++ b/src/writers/CdmNewspapers.php
@@ -260,21 +260,27 @@ class CdmNewspapers extends Writer
                 }
             }
             
-        }
-        
-        //$doc->formatOutput = true;
-
-        //$modsxml = $doc->saveXML();
-        // Create a directory for each day of the newspaper by getting
-        // the date value from the issue's metadata.
-        //$issue_object_info = get_item_info($results_record['collection'], $results_record['pointer']);
+        }    
         
         $issueObjectPath = $this->outputDirectory . DIRECTORY_SEPARATOR . $this->issueDate;
+                
+        // if the issue level directory already exists, we are dealing with a possible
+        // duplicate (or more) upload into CDM.  Create additional directories with
+        // #\d\d\d\d-\d\d\-\d\d\.\d# naming convention and log possible duplicate Cdm
+        // object so that the best choice(s) for the issue are selected during QA prior
+        // to batch ingest into Islandora or other systems.
+        $multipleIssueNumber = 0;
+        while(file_exists($issueObjectPath) == true) {
+            $multipleIssueNumber += 1;
+            $issueObjectPath = $issueObjectPath . "." . $multipleIssueNumber;
+        }
+        
         if (!file_exists($issueObjectPath)) {
             mkdir($issueObjectPath);
             // return issue_object_path for use when writing files.
             return $issueObjectPath;
         }
+        
     }
 
     public function writeMetadataFile($metadata, $path)

--- a/src/writers/CdmNewspapers.php
+++ b/src/writers/CdmNewspapers.php
@@ -75,8 +75,8 @@ class CdmNewspapers extends Writer
         $this->metadataParser = new $metadtaClass($settings);
         
         // Set up logger.
-        $this->pathToLog = $this->settings['LOGGING']['path_to_manipulator_log'];
-        $this->log = new \Monolog\Logger('config');
+        $this->pathToLog = $this->settings['LOGGING']['path_to_log'];
+        $this->log = new \Monolog\Logger('Writer');
         $this->logStreamHandler = new \Monolog\Handler\StreamHandler($this->pathToLog,
             Logger::INFO);
         $this->log->pushHandler($this->logStreamHandler);
@@ -90,7 +90,7 @@ class CdmNewspapers extends Writer
     {
         // Create root output folder
         $this->createOutputDirectory();
-        $issueObjectPath = $this->createIssueDirectory($metadata);
+        $issueObjectPath = $this->createIssueDirectory($metadata, $record_key);
         $this->writeMetadataFile($metadata, $issueObjectPath);
         
         // filegetter for OBJ.tiff files for newspaper issue pages
@@ -247,7 +247,7 @@ class CdmNewspapers extends Writer
         parent::createOutputDirectory();
     }
 
-    public function createIssueDirectory($metadata)
+    public function createIssueDirectory($metadata, $record_key)
     {
         //value of dateIssued isuse is the the title for the directory
         
@@ -279,15 +279,19 @@ class CdmNewspapers extends Writer
         // to batch ingest into Islandora or other systems.
         $multipleIssueNumber = 0;
         while(file_exists($issueObjectPath) == true) {
-            $this->log->addInfo("CdmNewspaperWriter", array('Newspaper issue already exits in output directory:' => $issueObjectPath));
-            $multipleIssueNumber += 1;
-            $issueObjectPath = $issueObjectPath . "." . $multipleIssueNumber;
             // log that the issue directory already exists and may indicate that the newspaper
             // issue may already exit in the output directory or that more than one Cdm
             // pointer refers to the same newspaper issue (multiple Cdm upload for same
-            // newspaper issue.
-            
-            
+            // newspaper issue.                    
+            $this->log->addInfo("CdmNewspaperWriter", 
+                array(
+                    'Newspaper issue already exits in output directory:' => $issueObjectPath,
+                    'pointer:' => $record_key
+                )
+            );
+                
+            $multipleIssueNumber += 1;
+            $issueObjectPath = $issueObjectPath . "." . $multipleIssueNumber;
         }
         
         if (!file_exists($issueObjectPath)) {

--- a/src/writers/CdmNewspapers.php
+++ b/src/writers/CdmNewspapers.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace mik\writers;
+use Monolog\Logger;
 
 class CdmNewspapers extends Writer
 {
@@ -72,6 +73,13 @@ class CdmNewspapers extends Writer
         
         $metadtaClass = 'mik\\metadataparsers\\' . $settings['METADATA_PARSER']['class'];
         $this->metadataParser = new $metadtaClass($settings);
+        
+        // Set up logger.
+        $this->pathToLog = $this->settings['LOGGING']['path_to_manipulator_log'];
+        $this->log = new \Monolog\Logger('config');
+        $this->logStreamHandler = new \Monolog\Handler\StreamHandler($this->pathToLog,
+            Logger::INFO);
+        $this->log->pushHandler($this->logStreamHandler);
 
     }
 
@@ -271,8 +279,15 @@ class CdmNewspapers extends Writer
         // to batch ingest into Islandora or other systems.
         $multipleIssueNumber = 0;
         while(file_exists($issueObjectPath) == true) {
+            $this->log->addInfo("CdmNewspaperWriter", array('Newspaper issue already exits in output directory:' => $issueObjectPath));
             $multipleIssueNumber += 1;
             $issueObjectPath = $issueObjectPath . "." . $multipleIssueNumber;
+            // log that the issue directory already exists and may indicate that the newspaper
+            // issue may already exit in the output directory or that more than one Cdm
+            // pointer refers to the same newspaper issue (multiple Cdm upload for same
+            // newspaper issue.
+            
+            
         }
         
         if (!file_exists($issueObjectPath)) {


### PR DESCRIPTION
Handles newspaper issues that have been accidentally uploaded into Cdm more than once by adding  the dot-number to the end of the issue directory name.  Logs this to the MIK log.