### PR TITLE
Uses [SYSTEM][date_default_timezone] to be set in the configuraiton f…

### DIFF
--- a/mik
+++ b/mik
@@ -38,8 +38,6 @@ use League\CLImate\CLImate;
 use Cocur\BackgroundProcess\BackgroundProcess;
 
 use mik\exceptions\MikErrorException;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
 
 echo "Commencing MIK." . PHP_EOL;
 // Get command line options.
@@ -65,6 +63,22 @@ if (isset($options['limit'])) {
 // Instantiate a configuration.
 $mikConfig = new Config($configPath);
 $settings = $mikConfig->settings;
+
+// Monolog requires that the date.timezone PHP setting be set else
+// it will create an E_WARNING, which will be turned into an excption 
+// in the set_error_handler function halting the program.
+// Provide a default timezone if date.timezone is null in the the PHP INI.
+if (ini_get('date.timezone') == null || isset($settings['SYSTEM']['date_default_timezone'])) {
+    if(isset($settings['SYSTEM']['date_default_timezone'])){
+        $date_timezone = $settings['SYSTEM']['date_default_timezone'];
+        date_default_timezone_set($date_timezone);
+    } else {
+        // use a default time-zone.
+        date_default_timezone_set('America/Vancouver');
+    }
+};
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
 
 // Converts all errors into Exceptions.
 // Set here so that you can pass the configuration settings to the MIK Error Exception class.

--- a/mik
+++ b/mik
@@ -15,14 +15,6 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
     $onWindows = false;
 }
 
-// Monolog requires that the date.timezone PHP setting be set else
-// it will create an E_WARNING, which will be turned into an excption 
-// in the set_error_handler function halting the program.
-// Provide a default timezone if date.timezone is null in the the PHP INI.
-if (null == ini_get('date.timezone')) {
-    date_default_timezone_set('America/Vancouver');
-};
-
 // On Windows, opcache.enable_cli causes 'Fatal Error Unable to reattach
 // to base address' errors when running background processes, and causes
 // these processes to fail. Disable it at runtime.
@@ -30,16 +22,6 @@ if ($onWindows) {
     ini_set('opcache.enable_cli', '0');
 }
 
-// Use composer to load vendor and project classes.
-require 'vendor/autoload.php';
-
-use mik\config\Config;
-use League\CLImate\CLImate;
-use Cocur\BackgroundProcess\BackgroundProcess;
-
-use mik\exceptions\MikErrorException;
-
-echo "Commencing MIK." . PHP_EOL;
 // Get command line options.
 // Assumes --longopts.
 // Required --config=path/to/config/ini_file
@@ -60,25 +42,39 @@ if (isset($options['limit'])) {
     $limit = null;
 }
 
-// Instantiate a configuration.
-$mikConfig = new Config($configPath);
-$settings = $mikConfig->settings;
-
 // Monolog requires that the date.timezone PHP setting be set else
 // it will create an E_WARNING, which will be turned into an excption 
 // in the set_error_handler function halting the program.
 // Provide a default timezone if date.timezone is null in the the PHP INI.
-if (ini_get('date.timezone') == null || isset($settings['SYSTEM']['date_default_timezone'])) {
-    if(isset($settings['SYSTEM']['date_default_timezone'])){
-        $date_timezone = $settings['SYSTEM']['date_default_timezone'];
+// Load [SYSTEM] stettings for user-defined default timeszone using config path
+$system_settings = parse_ini_file($configPath, true)['SYSTEM'];
+if (ini_get('date.timezone') == null || isset($system_settings['date_default_timezone'])) {
+    if(isset($system_settings['date_default_timezone'])){
+        $date_timezone = $system_settings['date_default_timezone'];
         date_default_timezone_set($date_timezone);
     } else {
         // use a default time-zone.
         date_default_timezone_set('America/Vancouver');
     }
 };
+
+
+// Use composer to load vendor and project classes.
+require 'vendor/autoload.php';
+
+use mik\config\Config;
+use League\CLImate\CLImate;
+use Cocur\BackgroundProcess\BackgroundProcess;
+
+use mik\exceptions\MikErrorException;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
+
+echo "Commencing MIK." . PHP_EOL;
+
+// Instantiate a configuration.
+$mikConfig = new Config($configPath);
+$settings = $mikConfig->settings;
 
 // Converts all errors into Exceptions.
 // Set here so that you can pass the configuration settings to the MIK Error Exception class.


### PR DESCRIPTION
Addresses https://github.com/MarcusBarnes/mik/issues/215.

The expected behavior is to use [SYSTEM][date_default_timezone] if it is set in the config or use the value from the PHP.ini.  If date.timezone is not set in the PHP.ini and no [SYSTEM][date_default_timezone] is set in the MIK configuration file for the given collection, default to 'America/Vancouver'.