### PR TITLE
Trim function on ['name'] in case the CDM gives extra whitespace

### DIFF
--- a/src/metadataparsers/mods/CdmToMods.php
+++ b/src/metadataparsers/mods/CdmToMods.php
@@ -106,7 +106,7 @@ class CdmToMods extends Mods
         foreach ($objectInfo as $key => $value) {
             // $key is the 'nick'
             $fieldAttributes = $this->getFieldAttribute($key);
-            $name = $fieldAttributes['name'];
+            $name = trim($fieldAttributes['name']);
             $CONTENTdmFieldValuesArray[$name] = $value;
         }
         return $CONTENTdmFieldValuesArray;


### PR DESCRIPTION
Sometimes our mappings file would not match the output of the CDM data which sometimes included extra whitespace.