### PR TITLE
Adds verify_ca system setting to configuration in Oaipmh writer

### DIFF
--- a/src/config/Config.php
+++ b/src/config/Config.php
@@ -31,6 +31,17 @@ class Config
         $this->logStreamHandler= new \Monolog\Handler\StreamHandler($this->pathToLog, Logger::INFO);
         $this->log->pushHandler($this->logStreamHandler);
 
+        // Default Mac PHP setups may use Apple's Secure Transport
+        // rather than OpenSSL, causing issues with CA verification.
+        // Allow configuration override of CA verification at users own risk.
+        if (isset($this->settings['SYSTEM']['verify_ca']) ){
+            if($this->settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
+
         if (count($this->settings['CONFIG'])) {
             foreach ($this->settings['CONFIG'] as $config => $value) {
                 $this->log->addInfo("MIK Configuration", array($config => $value));
@@ -139,7 +150,7 @@ class Config
                         $value .= 'getthumbnail';
                     }
                     try {
-                        $response = $client->get($value);
+                        $response = $client->get($value, ['verify' => $this->verifyCA]);
                         $code = $response->getStatusCode();
                     }
                     catch (RequestException $e) {

--- a/src/fetchermanipulators/CdmByDmDate.php
+++ b/src/fetchermanipulators/CdmByDmDate.php
@@ -41,6 +41,17 @@ class CdmByDmDate extends FetcherManipulator
         $this->alias = $settings['FETCHER']['alias'];
         $this->ws_url = $settings['FETCHER']['ws_url'];
 
+        // Default Mac PHP setups may use Apple's Secure Transport
+        // rather than OpenSSL, causing issues with CA verification.
+        // Allow configuration override of CA verification at users own risk.
+        if (isset($this->settings['SYSTEM']['verify_ca']) ){
+            if($this->settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
+
         parent::__construct();
     }
 
@@ -117,7 +128,7 @@ class CdmByDmDate extends FetcherManipulator
             $pointer . '/json';
         // Create a new Guzzle client to fetch the CPD (stucture)   file.
         $client = new Client();
-        $response = $client->get($query_url);
+        $response = $client->get($query_url, ['verify' => $this->verifyCA]);
         $body = $response->getBody();
         $dmmodified = json_decode($body, true);
         return $dmmodified[0];

--- a/src/filegetters/CdmCompound.php
+++ b/src/filegetters/CdmCompound.php
@@ -40,6 +40,17 @@ class CdmCompound extends FileGetter
             $this->settings['http_timeout'] = 60;
         }
 
+        // Default Mac PHP setups may use Apple's Secure Transport
+        // rather than OpenSSL, causing issues with CA verification.
+        // Allow configuration override of CA verification at users own risk.
+        if (isset($settings['SYSTEM']['verify_ca']) ){
+            if($settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
+
         // Set up logger.
         $this->pathToLog = $settings['LOGGING']['path_to_log'];
         $this->log = new \Monolog\Logger('CdmPhpDocuments filegetter');
@@ -93,7 +104,8 @@ class CdmCompound extends FileGetter
         try {
             $response = $client->get($query_url,
                 ['timeout' => $this->settings['http_timeout'],
-                'connect_timeout' => $this->settings['http_timeout']]
+                'connect_timeout' => $this->settings['http_timeout'],
+                'verify' => $this->verifyCA]
             );
             $item_structure = $response->getBody();
         }

--- a/src/filegetters/CdmNewspapers.php
+++ b/src/filegetters/CdmNewspapers.php
@@ -66,6 +66,17 @@ class CdmNewspapers extends FileGetter
             $this->settings['http_timeout'] = 60;
         }
 
+        // Default Mac PHP setups may use Apple's Secure Transport
+        // rather than OpenSSL, causing issues with CA verification.
+        // Allow configuration override of CA verification at users own risk.
+        if (isset($settings['SYSTEM']['verify_ca']) ){
+            if($settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
+
         if (isset($this->settings['allowed_file_extensions_for_OBJ'])) {
             $this->allowed_file_extensions_for_OBJ = $this->settings['allowed_file_extensions_for_OBJ'];
         }
@@ -112,7 +123,8 @@ class CdmNewspapers extends FileGetter
         try {
             $response = $client->get($query_url,
                 ['timeout' => $this->settings['http_timeout'], 
-                'connect_timeout' => $this->settings['http_timeout']]
+                'connect_timeout' => $this->settings['http_timeout'],
+                'verify' => $this->verifyCA]
             );
             $item_structure = $response->getBody();
             $item_structure = json_decode($item_structure, true);
@@ -235,7 +247,8 @@ class CdmNewspapers extends FileGetter
             $client = new Client();
             $response = $client->get($get_image_url_thumbnail,
                 ['timeout' => $this->settings['http_timeout'],
-                'connect_timeout' => $this->settings['http_timeout']]
+                'connect_timeout' => $this->settings['http_timeout'],
+                'verify' => $this->verifyCA]
             );
             $thumbnail_content = $response->getBody();
         }
@@ -266,7 +279,8 @@ class CdmNewspapers extends FileGetter
         try {
             $response = $client->get($get_image_url_jpg,
                 ['timeout' => $this->settings['http_timeout'],
-                'connect_timeout' => $this->settings['http_timeout']]
+                'connect_timeout' => $this->settings['http_timeout'],
+                'verify' => $this->verifyCA]
             );
             $jpg_content = $response->getBody();
             return $jpg_content;
@@ -291,7 +305,8 @@ class CdmNewspapers extends FileGetter
         try {
             $response = $client->get($get_file_url,
                 ['timeout' => $this->settings['http_timeout'],
-                'connect_timeout' => $this->settings['http_timeout']]
+                'connect_timeout' => $this->settings['http_timeout'],
+                'verify' => $this->verifyCA]
             );
             $content = $response->getBody();
             return $content;

--- a/src/filegetters/CdmPhpDocuments.php
+++ b/src/filegetters/CdmPhpDocuments.php
@@ -40,6 +40,17 @@ class CdmPhpDocuments extends FileGetter
             $this->settings['http_timeout'] = 60;
         }
 
+        // Default Mac PHP setups may use Apple's Secure Transport
+        // rather than OpenSSL, causing issues with CA verification.
+        // Allow configuration override of CA verification at users own risk.
+        if (isset($settings['SYSTEM']['verify_ca']) ){
+            if($settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
+
         // Set up logger.
         $this->pathToLog = $settings['LOGGING']['path_to_log'];
         $this->log = new \Monolog\Logger('CdmPhpDocuments filegetter');
@@ -100,7 +111,8 @@ class CdmPhpDocuments extends FileGetter
         try {
             $response = $client->get($get_file_url, ['stream' => true,
                 'timeout' => $this->settings['http_timeout'],
-                'connect_timeout' => $this->settings['http_timeout']]
+                'connect_timeout' => $this->settings['http_timeout'],
+                'verify' => $this->verifyCA]
             );
             $body = $response->getBody();
             while (!$body->eof()) {

--- a/src/filegetters/CdmSingleFile.php
+++ b/src/filegetters/CdmSingleFile.php
@@ -59,6 +59,17 @@ class CdmSingleFile extends FileGetter
             $this->settings['http_timeout'] = 60;
         }
 
+        // Default Mac PHP setups may use Apple's Secure Transport
+        // rather than OpenSSL, causing issues with CA verification.
+        // Allow configuration override of CA verification at users own risk.
+        if (isset($settings['SYSTEM']['verify_ca']) ){
+            if($settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
+
         // Set up logger.
         $this->pathToLog = $settings['LOGGING']['path_to_log'];
         $this->log = new \Monolog\Logger('CdmSingleFile filegetter');
@@ -99,7 +110,8 @@ class CdmSingleFile extends FileGetter
         try {
             $response = $client->get($get_file_url, ['stream' => true,
                 'timeout' => $this->settings['http_timeout'],
-                'connect_timeout' => $this->settings['http_timeout']]
+                'connect_timeout' => $this->settings['http_timeout'],
+                'verify' => $this->verifyCA]
             );
             $body = $response->getBody();
             while (!$body->eof()) {

--- a/src/filegetters/OaipmhOjsPdf.php
+++ b/src/filegetters/OaipmhOjsPdf.php
@@ -23,6 +23,14 @@ class OaipmhOjsPdf extends FileGetter
         $this->fetcher = new \mik\fetchers\Oaipmh($settings);
         $this->temp_directory = $this->settings['temp_directory'];
 
+        if (isset($settings['SYSTEM']['verify_ca']) ){
+            if($settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
+
         // Set up logger.
         $this->pathToLog = $settings['LOGGING']['path_to_log'];
         $this->log = new \Monolog\Logger('OaipmhOjsPdf filegetter');
@@ -78,7 +86,7 @@ class OaipmhOjsPdf extends FileGetter
 	// <a href="http://journals.sfu.ca/present/index.php/demojournal/article/view/6/9" class="file" target="_parent">PDF</a>
 	// </div>
         $client = new Client();
-        $response = $client->get($article_url);
+        $response = $client->get($article_url, [$this->verifyCA]);
         $body = $response->getBody();
 
         $dom = new \DOMDocument;

--- a/src/filegetters/OaipmhXpath.php
+++ b/src/filegetters/OaipmhXpath.php
@@ -2,7 +2,6 @@
 
 namespace mik\filegetters;
 
-use GuzzleHttp\Client;
 use mik\exceptions\MikErrorException;
 use Monolog\Logger;
 

--- a/src/metadatamanipulators/AddContentdmData.php
+++ b/src/metadatamanipulators/AddContentdmData.php
@@ -37,6 +37,17 @@ class AddContentdmData extends MetadataManipulator
         $this->record_key = $record_key;
         $this->alias = $this->settings['METADATA_PARSER']['alias'];
 
+        // Default Mac PHP setups may use Apple's Secure Transport
+        // rather than OpenSSL, causing issues with CA verification.
+        // Allow configuration override of CA verification at users own risk.
+        if (isset($this->settings['SYSTEM']['verify_ca']) ){
+            if($this->settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
+
         // Set up logger.
         $this->pathToLog = $this->settings['LOGGING']['path_to_manipulator_log'];
         $this->log = new \Monolog\Logger('config');
@@ -196,7 +207,7 @@ class AddContentdmData extends MetadataManipulator
               $cdm_api_function . '/' . $this->alias . '/' . $pointer . '/' . $format;
           $client = new Client();
           try {
-              $response = $client->get($url);
+              $response = $client->get($url, [$this->verifyCA]);
           } catch (Exception $e) {
               $this->log->addInfo("AddContentdmData",
                   array('HTTP request error' => $e->getMessage()));

--- a/src/writers/Oaipmh.php
+++ b/src/writers/Oaipmh.php
@@ -41,6 +41,17 @@ class Oaipmh extends Writer
         } else {
             $this->httpTimeout = 60;
         }
+
+        // Default Mac PHP setups may use Apple's Secure Transport
+        // rather than OpenSSL, causing issues with CA verification.
+        // Allow configuration override of CA verification at users own risk.
+        if (isset($this->settings['SYSTEM']['verify_ca']) ){
+            if($this->settings['SYSTEM']['verify_ca'] == false){
+              $this->verifyCA = false;
+            }
+        } else {
+            $this->verifyCA = true;
+        }
     }
 
     /**
@@ -67,7 +78,8 @@ class Oaipmh extends Writer
             $response = $client->get($source_file_url,
                 ['stream' => true,
                 'timeout' => $this->httpTimeout,
-                'connect_timeout' => $this->httpTimeout]
+                'connect_timeout' => $this->httpTimeout,
+                'verify' => $this->verifyCA]
             );
 
             // Lazy MimeType => extension mapping: use the last part of the MimeType.


### PR DESCRIPTION
Addresses issue #258 for Oaipmh writer.  @mjordan Please review with @bondjimbond and merge if satisfied.  You will need to add ```verify_ca = 0``` under the ```[SYSTEM]``` section of your configuration file.