### PR TITLE
Create kora_oai.ini

### DIFF
--- a/extras/bceln/kora_oai.ini
+++ b/extras/bceln/kora_oai.ini
@@ -1,0 +1,33 @@
+; MIK configuration file for an OAI-PMH toolchain.
+
+[CONFIG]
+config_id = KORA migration
+last_updated_on = "2016-11-23"
+last_update_by = "bw"
+
+[SYSTEM]
+date_default_timezone = 'America/Vancouver'
+verify_ca = 0
+
+[FETCHER]
+class = Oaipmh
+oai_endpoint = "http://kora.kpu.ca/do/oai/"
+metadata_prefix = oai_dc
+temp_directory = "/tmp/oaitest_temp"
+
+[METADATA_PARSER]
+class = dc\OaiToDc
+
+[FILE_GETTER]
+class = OaipmhXpath
+xpath_expression = "//dc:identifier[2]"
+temp_directory = "/tmp/oaitest_temp"
+
+[WRITER]
+class = Oaipmh
+output_directory = "/tmp/oaitest_output"
+
+
+[LOGGING]
+path_to_log = "/tmp/oaitest_output/mik.log"
+path_to_manipulator_log = "/tmp/oaitest_output/manipulator.log"


### PR DESCRIPTION
Provides sample configuration to download all files via a Digital Commons OAI-PMH feed.