### PR TITLE
Work on #291.

### DIFF
--- a/src/writers/CsvCompound.php
+++ b/src/writers/CsvCompound.php
@@ -57,6 +57,14 @@ class CsvCompound extends Writer
             $this->generate_child_modsxml = true;
         }
 
+        // Default minimum child count is 2.
+        if (isset($settings['WRITER']['min_children'])) {
+            $this->min_children = $settings['WRITER']['min_children'];
+        }
+        else {
+            $this->min_children = 2;
+        }
+        
         // Set up logger.
         $this->pathToLog = $this->settings['LOGGING']['path_to_log'];
         $this->log = new \Monolog\Logger('Writer');
@@ -78,6 +86,17 @@ class CsvCompound extends Writer
      */
     public function writePackages($metadata, $children, $record_id)
     {
+        if (count($children) < $this->min_children) {
+            $this->log->addError("Number of child files is lower than configured minimum",
+                array(
+                    'record ID' => $record_id,
+                    'number of child files' => count($children),
+                    'configured minimum' => $this->min_children
+                ));
+            $this->problemLog->addError($record_id);
+            return;
+        }
+
         // If there were no datastreams explicitly set in the configuration,
         // set flag so that all datastreams in the writer class are run.
         // $this->datastreams is an empty array by default.


### PR DESCRIPTION
**Github issue**: https://github.com/MarcusBarnes/mik/issues/291

# What does this Pull Request do?

Adds an optional .ini setting to define the minimum number of children that must be present in order for the CSV Compound toolchain to create a compound object ingest package.

# What's new?

1. New optional .ini setting `['WRITER']['min_children']`. Default is 2.
2. Logic to skip writing a package if the number of children is less than this config setting. Objects that are skipped are logged both to the mik.log file and to the problem_records.log.

# How should this be tested?

Run the CSV Compound toolchain against some objects, some of which should contain only one child object. They should be skipped and logged. Set `['WRITER']['min_children']` to a higher number to see if the setting is respected.

# Extra note

This is the first commit and PR created on Windows after the new .gitattributes settings are in effect.

