### PR TITLE
Work on #123.

### DIFF
--- a/mik
+++ b/mik
@@ -94,8 +94,8 @@ if (ini_get('date.timezone') == null || isset($system_settings['date_default_tim
 // Converts all errors into Exceptions.
 // Set here so that you can pass the configuration settings to the MIK Error Exception class.
 set_error_handler(
-    function ($severity, $file, $line, $message, $code) use ($settings) {
-        throw new mik\exceptions\MikErrorException($severity, $file, $line, $message, $code, $settings);
+    function ($severity, $message, $file, $line, $code) use ($settings) {
+        throw new mik\exceptions\MikErrorException($severity, $message, $file, $line, $code, $settings);
     }
 );
 

--- a/src/exceptions/MikErrorException.php
+++ b/src/exceptions/MikErrorException.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 class MikErrorException extends \ErrorException
 {
 
-    public function __construct($severity, $file, $line, $message = null, $code = 0, $settings)
+    public function __construct($severity, $message = null, $file, $line, $code = 0, $settings)
     {
         $pathToLog = $settings['LOGGING']['path_to_log'];
         $log = new Logger('ErrorException');


### PR DESCRIPTION
**Github issue**: #123

# What does this Pull Request do?

Makes exception logging more useful.

# What's new?

Changed order of arguments to MIK's custom exception handler to match the order documented at http://php.net/manual/en/function.set-error-handler.php.

# How should this be tested?

1. Check out the issue-123 branch
2. Run MIK on a toolchain that throws an exception (e.g., create a mapping that has XML errors in it).
3. The keys and values in entries in mik.log should match up. For example, the line numbers should now show up with the 'line' key.
