### PR TITLE
Issue 319

### DIFF
--- a/src/filegetters/CdmPdfDocuments.php
+++ b/src/filegetters/CdmPdfDocuments.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Client;
 use mik\exceptions\MikErrorException;
 use Monolog\Logger;
 
-class CdmPhpDocuments extends FileGetter
+class CdmPdfDocuments extends FileGetter
 {
     /**
      * @var array $settings - configuration settings from confugration class.

--- a/src/filegetters/CdmPhpDocuments.php
+++ b/src/filegetters/CdmPhpDocuments.php
@@ -101,10 +101,20 @@ class CdmPhpDocuments extends FileGetter
         // Retrieve the file associated with the object. In the case of PDF Documents,
         // the file is a single PDF comprised of all the page-level PDFs joined into a
         // single PDF file using the (undocumented) CONTENTdm API call below.
-        $get_file_url = $this->utilsUrl .'getdownloaditem/collection/'
-            . $this->alias . '/id/' . $pointer . '/type/compoundobject/show/1/cpdtype/document-pdf/filename/'
-            . $document_structure['page'][0]['pagefile'] . '/width/0/height/0/mapsto/pdf/filesize/0/title/'
-            . urlencode($document_structure['page'][0]['pagetitle']);
+        // Document-PDFs with only one page have a different structure than multiplage documents.
+        if (array_key_exists('pagefile', $document_structure['page'])) {
+            $get_file_url = $this->utilsUrl .'getdownloaditem/collection/'
+                . $this->alias . '/id/' . $pointer . '/type/compoundobject/show/1/cpdtype/document-pdf/filename/'
+                . $document_structure['page']['pagefile'] . '/width/0/height/0/mapsto/pdf/filesize/0/title/'
+                . urlencode($document_structure['page']['pagetitle']);
+
+        }
+        else {          
+            $get_file_url = $this->utilsUrl .'getdownloaditem/collection/'
+                . $this->alias . '/id/' . $pointer . '/type/compoundobject/show/1/cpdtype/document-pdf/filename/'
+                . $document_structure['page'][0]['pagefile'] . '/width/0/height/0/mapsto/pdf/filesize/0/title/'
+                . urlencode($document_structure['page'][0]['pagetitle']);
+        }
         // Create a new Guzzle client to fetch the PDF as a stream,
         // which will allow us to handle large PDF files.
         $client = new Client();

--- a/src/writers/CdmPdfDocuments.php
+++ b/src/writers/CdmPdfDocuments.php
@@ -2,7 +2,7 @@
 
 namespace mik\writers;
 
-class CdmPhpDocuments extends Writer
+class CdmPdfDocuments extends Writer
 {
     /**
      * @var array $settings - configuration settings from confugration class.


### PR DESCRIPTION
**Github issue**: #319 and #223

# What does this Pull Request do?

#319: Adds logic to accommodate single-page CONTENTdm PDF Documents.
#223: Changes the names of the writer and filegetter classes in the CONTENTdm compound PDF documents toolchain from "CdmPhpDocuments" to "CdmPdfDocuments". 

# What's new?

See code diff.

Since this PR changes the names of some classes, you must issue a `composer dump-autoload` command before running MIK. Jobs that use the CONTENTdm compound PDF documents toolchain will need to change the name of the `class` option in the [WRITER] and [FILEGETTER] sections of their .ini files.

# How should this be tested?

@MarcusBarnes I will send you an email with a .ini file that you can use to test this with.
