### PR TITLE
Work on #326 after the resolution of #329

### DIFF
--- a/src/fetchermanipulators/CdmSingleFileByExtension.php
+++ b/src/fetchermanipulators/CdmSingleFileByExtension.php
@@ -32,7 +32,7 @@ class CdmSingleFileByExtension extends FetcherManipulator
     public function __construct($settings, $manipulator_settings)
     {
         array_shift($manipulator_settings);
-        $this->extensions = explode('|', $manipulator_settings[0]);
+        $this->extensions = explode(',', $manipulator_settings[0]);
         // To get the value of $onWindows.
         parent::__construct();
     }

--- a/src/fetchermanipulators/CsvSingleFileByExtension.php
+++ b/src/fetchermanipulators/CsvSingleFileByExtension.php
@@ -27,7 +27,7 @@ class CsvSingleFileByExtension extends FetcherManipulator
     {
         // We remove the first member of $manipulator_settings since it contains
         // the classname of this class.
-        $this->allowed_extensions = explode('|', $manipulator_settings[1]);
+        $this->allowed_extensions = explode(',', $manipulator_settings[1]);
         $this->file_name_field = $settings['FILE_GETTER']['file_name_field'];
         // To get the value of $onWindows.
         parent::__construct();        

--- a/src/fetchermanipulators/RandomSet.php
+++ b/src/fetchermanipulators/RandomSet.php
@@ -38,6 +38,15 @@ class RandomSet extends FetcherManipulator
     public function __construct($settings, $manipulator_settings)
     {
         $this->setSize = $manipulator_settings[1];
+        if (isset($manipulator_settings[2])) {
+            $this->outputFile = $manipulator_settings[2];          
+            $now = date("F j, Y, g:i a");
+            $message = "# Output of the MIK Random Set fetcher manipulator, generated $now" . PHP_EOL;
+            if (file_exists($this->outputFile)) {
+                $message = PHP_EOL . $message;
+            }
+            file_put_contents($this->outputFile, $message, FILE_APPEND);
+        }
         // To get the value of $onWindows.
         parent::__construct();
     }
@@ -68,6 +77,17 @@ class RandomSet extends FetcherManipulator
             if (in_array($record_num, $randomSet)) {
                 $filtered_records[] = $record;
             }
+
+            if (isset($this->outputFile)) {
+                if ($record_num < count($randomSet) - 1) {
+                    $record->key = $record->key . PHP_EOL;
+                    file_put_contents($this->outputFile, $record->key, FILE_APPEND);
+                }
+                if ($record_num === count($randomSet)) {
+                    file_put_contents($this->outputFile, $record->key, FILE_APPEND);
+                }
+            }
+
             $record_num++;
             if ($this->onWindows) {
                 print '.';

--- a/src/fetchers/Csv.php
+++ b/src/fetchers/Csv.php
@@ -169,7 +169,7 @@ class Csv extends Fetcher
     private function applyFetchermanipulators($records)
     {
         foreach ($this->fetchermanipulators as $manipulator) {
-            $manipulator_settings_array = explode('|', $manipulator, 2);
+            $manipulator_settings_array = explode('|', $manipulator);
             $manipulator_class = '\\mik\\fetchermanipulators\\' . $manipulator_settings_array[0];
             $fetchermanipulator = new $manipulator_class($this->all_settings,
                 $manipulator_settings_array);

--- a/tests/FetcherManipulatorTest.php
+++ b/tests/FetcherManipulatorTest.php
@@ -137,7 +137,7 @@ class FetcherManipulatorTest extends \PHPUnit_Framework_TestCase
                 'file_name_field' => 'File',
              ),
             'MANIPULATORS' => array(
-                'fetchermanipulators' => array('CsvSingleFileByExtension|jpg|jpeg'),
+                'fetchermanipulators' => array('CsvSingleFileByExtension|jpg,jpeg'),
              ),
         );
         $csv = new Csv($settings);


### PR DESCRIPTION
**Github issue**: (#326)

# What does this Pull Request do?

Provides an option for the Random Set fetcher manipulator to write out the record keys of the randomly chosen records to a file.

# What's new?

Introduces an optional second parameter to the Random Set manipulator (path to the file to write the keys to), and logic to set up and write to the file, including a header that indicates when the file was generated. I also had to remove the limit of 2 parameters to where to fetcher manipulators are invoked.

# How should this be tested?
I'm attaching a zip that contains an .ini file, a mappings file, and a CSV input. Image files are not required to this test.

1. check out the issue-326 branch.
1. adjust the file paths in the .ini file to suit your local environment.
1. run mik using the .ini file. MIK should write a file called "issue-326.txt" to the mik installation directory containing 100 record keys.
1. delete "issue-326.txt".
1. remove the filename from the `RandomSet` manipulator signature and rerun mik. MIK should not write a file called "issue-326.txt".

[issue-326.zip](https://github.com/MarcusBarnes/mik/files/818199/issue-326.zip)



# Interested parties
@MarcusBarnes 
