### PR TITLE
Work on #323.

### DIFF
--- a/src/config/Config.php
+++ b/src/config/Config.php
@@ -352,6 +352,13 @@ class Config
         foreach ($rows as $row) {
             $row_num++;
             $columns_in_row = count($row);
+
+            // Empty row.
+            if ($columns_in_row == 1) {
+                print "Row $row_num in the CSV input file appears to be empty; this is OK, just reporting it in case it's unintentional." . PHP_EOL;
+                continue;
+            }
+
             if ($columns_in_row != $num_header_columns) {
                 $csv_has_errors = true;
                 print "Error with CSV input file: it appears that row $row_num does not have " .


### PR DESCRIPTION
**Github issue**: (#323)

# What does this Pull Request do?

Makes `--checkconfig` report blank rows in CSV input files.

# What's new?

Logic in src/config/Config.php to check for a blank row in the input file.

All tests pass with this change in place.

# How should this be tested?

1. Check out the issue-323 branch.
1. Add one or more empty rows to the MIK tutorial CSV input file and run mik on it: `./mik -c /tmp/mik_tutorial_data/tutorial_config.ini --checkconfig all`
1. For each empty row in the input file, MIK should report `Row X in the CSV input file appears to be empty; this is OK, just reporting it in case it's unintentional.`




# Interested parties
@jpeak5 @MarcusBarnes 
