### PR TITLE
Work on #356.

### DIFF
--- a/src/config/Config.php
+++ b/src/config/Config.php
@@ -133,7 +133,7 @@ class Config
 
         $reader = Reader::createFromPath($path);
         foreach ($reader as $index => $row) {
-            if (count($row) > 1) {
+            if (count($row) > 1 && !preg_match('/^#/', $row[0]) ) {
                 if (strlen($row[1])) {
                     $doc = new \DOMDocument();
                     if (!@$doc->loadXML($row[1])) {


### PR DESCRIPTION
**Github issue**: (#356)

# What does this Pull Request do?

Makes `--checkconfig` skip mappings that are commented out with a #.

# What's new?
A check within the Config.php class for a leading # in mappings files. If the # is present, the mapping is not checked.

# How should this be tested?

1. Check out the issue-356 branch.
1. Using the attached .ini, mappings, and input file, run `./mik -c issue_356.ini -cc all`
1. You should see a message saying "Error: Mapping snippet <ubject><topic>%value%</topic></subject> appears to be not well formed".
1. Open the issue_356_mappings.csv file and comment out the Subject mapping row with a #.
1. Rerun  `./mik -c issue_356.ini -cc all`.
1. You should not see the error any longer.

You will need to remove the .txt extension from the attached files.

[issue_356.ini.txt](https://github.com/MarcusBarnes/mik/files/866759/issue_356.ini.txt)
[issue_356_metadata.csv.txt](https://github.com/MarcusBarnes/mik/files/866763/issue_356_metadata.csv.txt)
[issue_356_mappings.csv.txt](https://github.com/MarcusBarnes/mik/files/866764/issue_356_mappings.csv.txt)