### PR TITLE
Issue 359

### DIFF
--- a/src/filegetters/OaipmhIslandoraObj.php
+++ b/src/filegetters/OaipmhIslandoraObj.php
@@ -63,42 +63,34 @@ class OaipmhIslandoraObj extends FileGetter
         $dom = new \DOMDocument;
         $xml = file_get_contents($raw_metadata_path);
         $dom->loadXML($xml);
-        // Loop through all the dc:identifer elements.
-        foreach ($dom->getElementsByTagNameNS('http://purl.org/dc/elements/1.1/', 'identifier') as $identifier) {
-            // This scary looking regex pattern identifies a valid Fedora PID.
-            if (preg_match('/^([A-Za-z0-9]|-|\.)+:(([A-Za-z0-9])|-|\.|~|_|(%[0-9A-F]{2}))+$/', trim($identifier->nodeValue))) {
-                $pid = trim($identifier->nodeValue);
-                $islandora_url_info = parse_url($this->oai_endpoint);
-                if (isset($islandora_url_info['port'])) {
-                    $port = $islandora_url_info['port'];
+        // There will only be one oai:identifer element. Islandora's OAI identifiers look like
+        // oai:digital.lib.sfu.ca:foo_112, 'foo_123' being the object's PID.
+        $identifier = $dom->getElementsByTagNameNS('http://www.openarchives.org/OAI/2.0/', 'identifier')->item(0);
+        $raw_pid = preg_replace('#.*:#', '', trim($identifier->nodeValue));
+        $pid = preg_replace('/_/', ':', $raw_pid);
+            $islandora_url_info = parse_url($this->oai_endpoint);
+            if (isset($islandora_url_info['port'])) {
+                $port = $islandora_url_info['port'];
+            }
+            else {
+                $port = '';
+            }
+            $islandora_host = $islandora_url_info['scheme'] . '://' . $islandora_url_info['host'] . $port;
+            // Assemble the URL of each datastream listed in the config and return on the first one
+            // that is available. We loop through DSIDs because not all Islandora content models
+            // require an OBJ datastream, e.g., PDF, video and audio content models.
+            foreach ($this->datastreamIds as $dsid) {
+                $ds_url = $islandora_host . '/islandora/object/' . $pid . '/datastream/' . $dsid . '/download';
+                // HEAD is probably more efficient than the default GET.
+                stream_context_set_default(array('http' => array('method' => 'HEAD')));
+                $headers = get_headers($ds_url, 1);
+                if ($headers[0] == 'HTTP/1.1 200 OK') {
+                    return $ds_url;
                 }
-                else {
-                    $port = '';
-                }
-                $islandora_host = $islandora_url_info['scheme'] . '://' . $islandora_url_info['host'] . $port;
-                // Assemble the URL of each datastream listed in the config and return on the first one
-                // that is available. We loop through DSIDs because not all Islandora content models
-                // require an OBJ datastream, e.g., PDF, video and audio content models.
-                foreach ($this->datastreamIds as $dsid) {
-                    $ds_url = $islandora_host . '/islandora/object/' . $pid . '/datastream/' . $dsid . '/download';
-                    // HEAD is probably more efficient than the default GET.
-                    stream_context_set_default(
-                        array(
-                            'http' => array(
-                                'method' => 'HEAD'
-                             )
-                        )
-                    );
-                    $headers = get_headers($ds_url, 1);
-                    if ($headers[0] == 'HTTP/1.1 200 OK') {
-                        return $ds_url;
-                    }
-                }
-                // If no datastreams are available, return false.
-                return false;
-             }
-         }
-         // If no dc:identifiers contain what appears to be a PID (unlikely, but possible), return false.
-         return false;
+            }
+            // If no datastreams listed in $this->datastreamIds are available, return false.
+            return false;
+        // If no oai:identifiers contain what appears to be a PID (unlikely, but possible), return false.
+        return false;
     }
 }


### PR DESCRIPTION
**Github issue**: (#359)

# What does this Pull Request do?

Adds as the ability to harvest datastreams other than OBJ using the OaipmhIslandoraObj filegetter class.

# What's new?

In the config, the option `[WRITER] datastream_ids[]` must contain at least one DSID, e.g. OBJ. For example:

```
[WRITER] datastream_ids[] = OBJ
[WRITER] datastream_ids[] = PDF
```
The filegetter loops through this list and issues a HEAD request for each datastream; it returns with the URL of the first one that it gets a 200 HTTP response for.

This PR also changes the logic within the fiegetter so that it gets the object's PID from the oai:identifier element, not dc:identifier, which it was always intended to do.

# How should this be tested?

1. Check out the issue-359 branch.
1. Run mik using the attached .ini file. It will create  20 ingest packages containing .jpeg files.
1. Delete the MIK output directory.
1. Open the .in file and comment out the `hbc_collection` setspec and uncomment the `cciced_collection` setspec.
1. Rerun mik but use the `-l 20` option (e.g. `./mik -c issue-359.ini.txt -l 20`). It will create 20 ingest packages containing .dpf files

# Interested parties
@bondjimbond if you could test, @MarcusBarnes can merge. I'll then update https://github.com/MarcusBarnes/mik/wiki/Toolchain:-OAI-PMH-for-Islandora-repositories.

[issue-359.ini.txt](https://github.com/MarcusBarnes/mik/files/870109/issue-359.ini.txt)



