### PR TITLE
Work on #361.

### DIFF
--- a/src/metadatamanipulators/InsertXmlFromTemplate.php
+++ b/src/metadatamanipulators/InsertXmlFromTemplate.php
@@ -52,6 +52,8 @@ class InsertXmlFromTemplate extends MetadataManipulator
          if ($this->fieldName == $this->sourceField) {
              $loader = new \Twig_Loader_Filesystem($this->templateDirectory);
              $twig = new \Twig_Environment($loader);
+             $custom_filter = new \Twig_SimpleFilter('TwigTruncate', array($this, 'TwigTruncate'));
+             $twig->addFilter($custom_filter);
              $metadata = $this->getSourceMetadata();
              $xml_from_template = $twig->render($this->templateFilename, (array) $metadata);
              return trim($xml_from_template);
@@ -102,4 +104,38 @@ class InsertXmlFromTemplate extends MetadataManipulator
           );
       }
 
+    /**
+     * Custom Twig filter to truncate a string to a specific length.
+     *
+     * Will truncate at the prceding word boundary, which means that
+     * the returned string may be empty.
+     *
+     * Example: <title>{{ Title|TwigTruncate(20) }} [...]</title>
+     *
+     * @param string $string
+     *   The string to truncate.
+     * @param int $length
+     *   The length at which to truncate the string.
+     *
+     * @return string
+     *   The truncated string. If the wordsafe string has been truncated
+     *   to be '', the original string is returned instead.  
+     */
+     public function TwigTruncate($string, $length)
+     {
+         // First truncate the string.
+         $truncated = substr($string, 0, $length);
+         // Then determine what the nearest preceding word boundary is,
+         // tokenizing the words on ' '.
+         $tokenized_words = explode(' ', $truncated);
+         array_pop($tokenized_words);
+         $wordsafe_string = implode(' ', $tokenized_words);
+
+         if (strlen($wordsafe_string) === 0) {
+             return $string;
+         }
+         else {
+             return $wordsafe_string;
+         }
+     }
 }


### PR DESCRIPTION
**Github issue**: (#361)

[Islandora group thread on the 255 character issue](https://groups.google.com/forum/#!searchin/islandora/255%7Csort:relevance/islandora/cm_6zCt-3PY/JuMnRDQfEQAJ) is also relevant.

# What does this Pull Request do?

Adds a custom Twig filter to the  InsertXmlFromTemplate metadata manipulator that truncates a string at a specified length minus the number of characters to the nearest preceding word break. Twig's built-in 'slice' filter does not respect word boundaries.

# What's new?
The addition to the  InsertXmlFromTemplate metadata manipulator of a custom Twig filter. The filter is used like this in Twig templates:

```xml
  <titleInfo>
     {# The paramter '30' is the length at which to trim the Title string. #}
     <title>{{ Title|TwigTruncate(30) }}</title>
  </titleInfo>
```

# How should this be tested?

1. Check out the issue-361 branch.
1. Using the files in the attached .zip file, run MIK: `./mik -c issue_361.ini`.

The `<title>` elements in the resulting MODS files will be truncated as follows. Titles that were longer than 30 characters in the input metadata have been truncated to less than 30, and truncated on the nearest word boundary:

-  image01: Small boats in Havana Harbour (original title was 45 characters, truncated title is 29)
-  image02: Manhatten Island (original title was 16 characters, truncated title is 16; title not truncated)
-  image03: Looking across Burrard Inlet (original title was 30 characters, truncated title is 30; title not truncated)
-  image04: Amsterdam waterfront in a (original title was 34 characters, truncated title is 25)
-  image05: Alcatraz Island from (original title was 39 characters, truncated title is 20)

# Additional Notes

This new custom filter can truncate any string, not just titles.

[issue_361.zip](https://github.com/MarcusBarnes/mik/files/871440/issue_361.zip)


