### PR TITLE
Work on #367.

### DIFF
--- a/src/metadatamanipulators/SimpleReplace.php
+++ b/src/metadatamanipulators/SimpleReplace.php
@@ -39,6 +39,12 @@ class SimpleReplace extends MetadataManipulator
             // A replacement string.
             $this->replacementText = $paramsArray[1];
         }
+        elseif (count($paramsArray) == 1) {
+            // A PHP preg_ pattern to match the original value on.
+            $this->replacePattern = $paramsArray[0];
+            // Empty replacement.
+            $this->replacementText = '';
+        }
         else {
             $this->log->addInfo("SimpleReplace", array('Wrong parameter count' => count($paramsArray)));
         }


### PR DESCRIPTION
**Github issue**: (#367)

# What does this Pull Request do?

Fixes a bug in the Simple Replace metadata manuipulator.

# What's new?
Registering the SimpleReplace metadata manipulator with an empty replacement string, like this:

`metadatamanipulators[] = "SimpleReplace|/foo/|''"`

Results in `''` replacing the target text defined in the pattern. On the other hand, leaving the second parameter emtpy, like this:

`metadatamanipulators[] = "SimpleReplace|/foo/|"`

results in a "wrong parameter count" error in mik.log.

This PR allows the use of the following to replace the target text with nothing, e.g., to remove it:

` metadatamanipulators[] = "SimpleReplace|/foo/|"`

# How should this be tested?

1. Unzip the attached file, which contains an .ini and metadata CSV plus mappings.
1. Check out the issue-367 branch.
1. Run mik using the `metadatamanipulators[] = "SimpleReplace|/foo/|''"` configuration.
1. Look at the MODS files for image01 and image03. They will have `''` in their titles.
1. Rerun mik usig the `metadatamanipulators[] = "SimpleReplace|/foo/|"` configuration.
1. The MODS files for image01 and image03 will not have `''` in their titles.

# Additional Notes:
Documentation at https://github.com/MarcusBarnes/mik/wiki/Metadata-manipulator:-SimpleReplace will need to be updated.

# Interested parties
@MarcusBarnes 

[issue_367.zip](https://github.com/MarcusBarnes/mik/files/877496/issue_367.zip)

