### PR TITLE
Work on #257.

### DIFF
--- a/src/writers/Oaipmh.php
+++ b/src/writers/Oaipmh.php
@@ -42,6 +42,13 @@ class Oaipmh extends Writer
             $this->httpTimeout = 60;
         }
 
+        if (isset($this->settings['WRITER']['metadata_only'])) {
+            // Seconds.
+            $this->metadata_only = $this->settings['WRITER']['metadata_only'];
+        } else {
+            $this->metadata_only = false;
+        }
+
         // Default Mac PHP setups may use Apple's Secure Transport
         // rather than OpenSSL, causing issues with CA verification.
         // Allow configuration override of CA verification at users own risk.
@@ -63,15 +70,17 @@ class Oaipmh extends Writer
         $this->createOutputDirectory();
         $output_path = $this->outputDirectory . DIRECTORY_SEPARATOR;
 
+        $normalized_record_id = $this->normalizeFilename($record_id);
+        $metadata_file_path = $output_path . $normalized_record_id . '.xml';
+        $this->writeMetadataFile($metadata, $metadata_file_path, true);
+
+	if ($this->metadata_only) {
+	  return;
+	}
+
         // Retrieve the file associated with the document and write it to the output
         // folder using the filename or record_id identifier
         $source_file_url = $this->fileGetter->getFilePath($record_id);
-
-        $normalized_record_id = $this->normalizeFilename($record_id);
-        $metadata_file_path = $output_path . $normalized_record_id . '.xml';
-
-        $this->writeMetadataFile($metadata, $metadata_file_path, true);
-
         // Retrieve the PDF, etc. using Guzzle.
         if ($source_file_url) {
             $client = new Client();


### PR DESCRIPTION
**Github issue**: (#257)

# What does this Pull Request do?

Adds an option to the OAI-PMH writer to harvest OAI metadata only, skipping the payload files.

# What's new?

For OAI-PMH toolchains, there is a new config option:
```
[WRITER]
metadata_only = true
```
If set to `true`, the writer skips downloading any other files such as PDFs, images, etc.

# How should this be tested?

1. check out the issue-257 branch.
1. using the attached config file, run MIK.  It should produce about 20 JPEG+XML ingest packages.
1. delete your output and temp directories.
1. in the config file, uncomment the `metadata_only = true` option
1. return mik
1. the output directory should now contain only XML files.

# Additional Notes
We will need to update the documentation for the OAI-PMH toolchains.

# Interested parties

@bondjimbond can you test?

[issue-257.ini.txt](https://github.com/MarcusBarnes/mik/files/884354/issue-257.ini.txt)

