### PR TITLE
Work on #371.

### DIFF
--- a/src/config/Config.php
+++ b/src/config/Config.php
@@ -119,8 +119,8 @@ class Config
      */
     public function checkMappingSnippets()
     {
-        $fetchers = array('Cdm', 'Csv');
-        if (!in_array($this->settings['FETCHER']['class'], $fetchers)) {
+        $parsers = array('mods\CsvToMods', 'mods\CdmToMods');
+        if (!in_array($this->settings['METADATA_PARSER']['class'], $parsers)) {
             return;
         }
 


### PR DESCRIPTION
**Github issue**: (#371)

# What does this Pull Request do?

Changes the .ini file validation so it only checks for mappings files when checking toolchains that use the 'mods\CsvToMods' and 'mods\CdmToMods' metadata parsers.

# What's new?

`--cc snippets` (or `--c all`) now only applies when the 'mods\CsvToMods' and 'mods\CdmToMods' metadata parsers are configured. This means that OAI-PMH toolchains, and toolchains that use the new Templated Metadata Parser, do not validate the metadata mappings files, which they don't use anyway.

# How should this be tested?

Using the .ini files in the attached zip, run the following:

* `./mik -c issue-371-oai.ini -cc all`
* `./mik -c issue-371-templated.ini -cc all`
* `./mik -c issue-371-csvmods.ini -cc all`

You should see no errors, and only the last command, using the issue-371-csvmods.ini file, should indicate that "Mapping snippets are OK".

# Interested parties
@MarcusBarnes 

[issue-371.zip](https://github.com/MarcusBarnes/mik/files/892007/issue-371.zip)
