### PR TITLE
Work on #324.

### DIFF
--- a/src/utilities/Dumper.php
+++ b/src/utilities/Dumper.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace mik\utilities;
+
+/**
+ * The Dumper...
+ */
+class Dumper
+{
+    /**
+     * Utility function to dump a variable to a log.
+     *
+     * @param $variable mixed
+     *   The variable to dump.
+     * @param $label string
+     *   A label to dump along with the value. Defaults to ''.
+     * @param $dest string
+     *   The full path to a log file. Defaults to the system's
+     *   temp directory with a filename of 'mik_dumper.txt'.
+     */
+    public function dump($variable, $label = '', $destination = null)
+    {
+        if (is_null($destination)) {
+            $destination = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_dumper.txt";
+        }
+        $value = var_export($variable, true) . "\n";
+        if (strlen($label)) {
+            $value = $label . ":\n" . $value;
+        }
+        file_put_contents($destination, $value, FILE_APPEND);
+    }
+}

--- a/src/utilities/Dumper.php
+++ b/src/utilities/Dumper.php
@@ -2,8 +2,10 @@
 
 namespace mik\utilities;
 
+use mik\exceptions\MikErrorException;
+
 /**
- * The Dumper...
+ * Utility to dump the value of a variable out to a log.
  */
 class Dumper
 {
@@ -18,14 +20,14 @@ class Dumper
      *   The full path to a log file. Defaults to the system's
      *   temp directory with a filename of 'mik_dumper.txt'.
      */
-    public function dump($variable, $label = '', $destination = null)
+    public function dump($variable, $label = null, $destination = null)
     {
         if (is_null($destination)) {
             $destination = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_dumper.txt";
         }
         $value = var_export($variable, true) . "\n";
-        if (strlen($label)) {
-            $value = $label . ":\n" . $value;
+        if (!is_null($label)) {
+            $value = $label . ":" . PHP_EOL . $value;
         }
         file_put_contents($destination, $value, FILE_APPEND);
     }


### PR DESCRIPTION
**Github issue**: (#324)

# What does this Pull Request do?

Adds a utility class "Dumper" that lets you dump the value of a variable to a file.

A new class, src/utilities/Dumper, that provides a single method, `->dump()`.

# How should this be tested?

* Check out the issue-324 branch.
* Run `composer dump-autoload` or equivalent on your system.
* Instantiate a new dumper by adding the following lines to the mik script at line 235:

```php
$dumper = new \mik\utilities\Dumper();
$dumper->dump($record, 'Record', '/tmp/foo.txt');
```

* Run mik using any working .ini file.
* The file /tmp/foo.txt should contain the dumped data.
* Open mik and delete the '/tmp/foo.txt' from the dumper parameters.
* Rerun MIK.
* The file /tmp/mik_dumper.txt should contain the dumped data.

# Additional Notes

@MarcusBarnes any thoughts on how I've set up the new 'utilities' namespace, etc.?

We can document how this utility works on the Information for Developer page.

# Interested parties
@MarcusBarnes 
