### PR TITLE
Work on #379.

### DIFF
--- a/src/metadatamanipulators/InsertXmlFromTemplate.php
+++ b/src/metadatamanipulators/InsertXmlFromTemplate.php
@@ -2,6 +2,7 @@
 // src/metadatamanipulators/InsertXmlFromTemplate.php
 
 namespace mik\metadatamanipulators;
+
 use \Twig\Twig;
 use \Monolog\Logger;
 
@@ -52,8 +53,10 @@ class InsertXmlFromTemplate extends MetadataManipulator
          if ($this->fieldName == $this->sourceField) {
              $loader = new \Twig_Loader_Filesystem($this->templateDirectory);
              $twig = new \Twig_Environment($loader);
-             $custom_filter = new \Twig_SimpleFilter('TwigTruncate', array($this, 'TwigTruncate'));
-             $twig->addFilter($custom_filter);
+
+             $truncate_filter = new \Twig_SimpleFilter('TwigTruncate', 'mik\utilities\MikTwigExtension::TwigTruncate');
+             $twig->addFilter($truncate_filter);
+
              $metadata = $this->getSourceMetadata();
              $xml_from_template = $twig->render($this->templateFilename, (array) $metadata);
              return trim($xml_from_template);
@@ -103,39 +106,4 @@ class InsertXmlFromTemplate extends MetadataManipulator
               'Unrecognized fetcher class' => $this->settings['FETCHER']['class'])
           );
       }
-
-    /**
-     * Custom Twig filter to truncate a string to a specific length.
-     *
-     * Will truncate at the prceding word boundary, which means that
-     * the returned string may be empty.
-     *
-     * Example: <title>{{ Title|TwigTruncate(20) }} [...]</title>
-     *
-     * @param string $string
-     *   The string to truncate.
-     * @param int $length
-     *   The length at which to truncate the string.
-     *
-     * @return string
-     *   The truncated string. If the wordsafe string has been truncated
-     *   to be '', the original string is returned instead.  
-     */
-     public function TwigTruncate($string, $length)
-     {
-         // First truncate the string.
-         $truncated = substr($string, 0, $length);
-         // Then determine what the nearest preceding word boundary is,
-         // tokenizing the words on ' '.
-         $tokenized_words = explode(' ', $truncated);
-         array_pop($tokenized_words);
-         $wordsafe_string = implode(' ', $tokenized_words);
-
-         if (strlen($wordsafe_string) === 0) {
-             return $string;
-         }
-         else {
-             return $wordsafe_string;
-         }
-     }
 }

--- a/src/metadataparsers/templated/Templated.php
+++ b/src/metadataparsers/templated/Templated.php
@@ -59,6 +59,10 @@ class Templated extends MetadataParser
     {
         $loader = new \Twig_Loader_Filesystem($this->templateDirectory);
         $twig = new \Twig_Environment($loader);
+
+        $truncate_filter = new \Twig_SimpleFilter('TwigTruncate', 'mik\utilities\MikTwigExtension::TwigTruncate');
+        $twig->addFilter($truncate_filter);
+
         $xml_from_template = $twig->render($this->templateFilename, (array) $objectInfo);
 
         if (isset($this->metadatamanipulators)) {

--- a/src/utilities/MikTwigExtension.php
+++ b/src/utilities/MikTwigExtension.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace mik\utilities;
+
+use mik\exceptions\MikErrorException;
+
+/**
+ * Class to provide MIK-specific Twig extensions.
+ *
+ * See the InsertXmlFromTemplate metadata manipulator and the Templated
+ * metadataparser for examples of how to implemnt methods defined in this class.
+ */
+class MikTwigExtension
+{
+    /**
+     * Custom Twig filter to truncate a string to a specific length.
+     *
+     * Will truncate at the prceding word boundary, which means that
+     * the returned string may be empty.
+     *
+     * Example: <title>{{ Title|TwigTruncate(20) }} [...]</title>
+     *
+     * @param string $string
+     *   The string to truncate.
+     * @param int $length
+     *   The length at which to truncate the string.
+     *
+     * @return string
+     *   The truncated string. If the wordsafe string has been truncated
+     *   to be '', the original string is returned instead.  
+     */
+     public static function TwigTruncate($string, $length)
+     {
+         // First truncate the string.
+         $truncated = substr($string, 0, $length);
+         // Then determine what the nearest preceding word boundary is,
+         // tokenizing the words on ' '.
+         $tokenized_words = explode(' ', $truncated);
+         array_pop($tokenized_words);
+         $wordsafe_string = implode(' ', $tokenized_words);
+
+         if (strlen($wordsafe_string) === 0) {
+             return $string;
+         }
+         else {
+             return $wordsafe_string;
+         }
+     }
+}


### PR DESCRIPTION
**Github issue**: (#379)

# What does this Pull Request do?

Moves the custom Twig filter TwigTruncate code to a utility class so it can be shared across metadatamanipulators and metadataparsers that use Twig templates.

# What's new?

Adds a new MIK utility class, src/utilities/MikTwigExtension.php, that is used within metadatamanipulators and metadataparsers like this:

```php
$truncate_filter = new \Twig_SimpleFilter('TwigTruncate', 'mik\utilities\MikTwigExtension::TwigTruncate');
$twig->addFilter($truncate_filter);
```

The custom TwigTruncate filter is then available in metadatamanipulators and metadataparsers using logic like this:

```xml
{% if Title|length < 30 %}
  <titleInfo>
     <title>{{ Title }}</title>
  </titleInfo>
{% else %}
  <titleInfo>
     <title>{{ Title|TwigTruncate(30) }}</title>
  </titleInfo>
{% endif %}
```

# How should this be tested?

Since this branch makes it possible to share code between a metadata parser and a metadata manipulator, we should test both.

1. Unzip the attached configuration and data files.
1. Check out the issue-379 branch and run `composer dump-autoload` or equivalent.
1. Test the Templated metadata parser first by running `./mik -c issue_379_parser.ini`. Output files will be in /tmp/issue_379_output.
1. image01.xml, image05.xml, and image05.xml will have titles that have been truncated at the word boundary closest to 30 characters (refer to the input file issue_379_metadata.csv to confirm this is the case).
1. Delete the /tmp/issue_379_output and /tmp/issue_379_temp directories.
1. Test the InsertXmlFromTemplate metadata manipulator first by running `./mik -c issue_379_manipulator.ini`. Output files will be in /tmp/issue_379_output.
1. image01.xml, image05.xml, and image05.xml will have titles that have been truncated at the word boundary closest to 30 characters (refer to the input file issue_379_metadata.csv to confirm this is the case).

[issue_379.zip](https://github.com/MarcusBarnes/mik/files/957077/issue_379.zip)


# Additional Notes

We should start a Cookbook entry that documents all of the MIK-specific Twig extenstions (currently there is only one).

# Interested parties
@MarcusBarnes
