### PR TITLE
Issue 383

### DIFF
--- a/src/inputvalidators/CsvNewspapers.php
+++ b/src/inputvalidators/CsvNewspapers.php
@@ -125,7 +125,7 @@ class CsvNewspapers extends MikInputValidator
                 );
                 $cumulative_validation_results[] = false;
             }
-            if (!$this->checkOcrFiles($issue_directory, $pages)) {
+            if (!$this->checkOcrFiles($issue_directory_full_path, $pages)) {
                 $this->log->addError(
                     "Input validation failed",
                     array(
@@ -281,7 +281,7 @@ class CsvNewspapers extends MikInputValidator
         foreach ($files as $file) {
             $pathinfo = pathinfo($file);
             $filename = $pathinfo['filename'];
-            $path_to_ocr_file = $issue_directory_path . DIRECTORY_SEPARATOR .
+            $path_to_ocr_file = realpath($issue_directory_path) . DIRECTORY_SEPARATOR .
                 $filename . $this->ocr_extension;
             if (!file_exists($path_to_ocr_file)) {
                 $valid = false;

--- a/tests/CsvInputValidatorsTest.php
+++ b/tests/CsvInputValidatorsTest.php
@@ -114,6 +114,9 @@ class CsvInputValidatorsTest extends \PHPUnit_Framework_TestCase
                  'input_directory' => dirname(__FILE__) . '/assets/csv/inputvalidators/csvnewspapers/files',
                  'file_name_field' => 'Directory',
             ),
+            'WRITER' => array(
+                'log_missing_ocr_files' => TRUE,
+            ),
             'LOGGING' => array(
                 'path_to_log' => $this->path_to_log,
                 'path_to_validator_log' => $this->path_to_input_validator_log,
@@ -123,21 +126,26 @@ class CsvInputValidatorsTest extends \PHPUnit_Framework_TestCase
         $inputValidator = new \mik\inputvalidators\CsvNewspapers($settings);
         $inputValidator->validateAll();
         $log_file_entries = file($this->path_to_input_validator_log);
-        $this->assertCount(3, $log_file_entries, "CSV Newspapers input validator log has the wrong number of entries");
+        $this->assertCount(6, $log_file_entries, "CSV Newspapers input validator log has the wrong number of entries");
         $this->assertContains(
             '"issue directory":"1900-0102","error":"Issue directory name is not in yyyy-mm-dd format"',
-            $log_file_entries[0],
+            $log_file_entries[1],
             "CSV Newspapers input validator did not detect non-yyyy-mm-dd directory name"
         );
         $this->assertContains(
             '"issue directory":"1900-01-03","error":"Issue directory not found in list of possible input directories"',
-            $log_file_entries[1],
+            $log_file_entries[3],
             "CSV Newspapers input validator did not find issue directory in input directories"
         );
         $this->assertContains(
             '"issue directory":"1900-01-04","error":"Some pages in issue directory have invalid sequence numbers"',
-            $log_file_entries[2],
+            $log_file_entries[5],
             "CSV Newspapers input validator did not detect invalid page sequences"
+        );
+        $this->assertContains(
+            '"issue directory":"1900-01-04","error":"Issue directory is missing one or more OCR files"',
+            $log_file_entries[4],
+            "CSV Newspapers input validator did not detect missing OCR files"
         );
     }
 

--- a/tests/XCsvNewspaperToolchainTest.php
+++ b/tests/XCsvNewspaperToolchainTest.php
@@ -166,6 +166,11 @@ XML;
             $this->path_to_output_dir . DIRECTORY_SEPARATOR . 'TT0002/3/OBJ.tif',
             "OBJ.tif file was not written by CsvNewspapers toolchain."
         );
+
+        $this->assertFileExists(
+            $this->path_to_output_dir . DIRECTORY_SEPARATOR . 'TT0002/3/OCR.txt',
+            "OCR.txt file was not written by CsvNewspapers toolchain."
+        );
     }
 
     protected function tearDown()
@@ -182,6 +187,7 @@ XML;
         foreach ($page_dirs as $page_dir) {
             $page_dir_path = $issue_dir . '/' . $page_dir;
             @unlink($page_dir_path . '/OBJ.tif');
+            @unlink($page_dir_path . '/OCR.txt');
             @unlink($page_dir_path . '/MODS.xml');
             @rmdir($page_dir_path);
         }

--- a/tests/assets/csv/newspapers/files/flat/1907-08-18/page-01.txt
+++ b/tests/assets/csv/newspapers/files/flat/1907-08-18/page-01.txt
@@ -1,0 +1,1 @@
+Page 1 OCR.

--- a/tests/assets/csv/newspapers/files/flat/1907-08-18/page-02.txt
+++ b/tests/assets/csv/newspapers/files/flat/1907-08-18/page-02.txt
@@ -1,0 +1,1 @@
+Page 2 OCR.

--- a/tests/assets/csv/newspapers/files/flat/1907-08-18/page-03.txt
+++ b/tests/assets/csv/newspapers/files/flat/1907-08-18/page-03.txt
@@ -1,0 +1,1 @@
+Page 3 OCR.

--- a/tests/assets/csv/newspapers/files/flat/1907-08-18/page-04.txt
+++ b/tests/assets/csv/newspapers/files/flat/1907-08-18/page-04.txt
@@ -1,0 +1,1 @@
+Page 4 OCR.

--- a/tests/assets/csv/newspapers/files/flat/1918-12-14/1918-12-14-01.txt
+++ b/tests/assets/csv/newspapers/files/flat/1918-12-14/1918-12-14-01.txt
@@ -1,0 +1,1 @@
+Page 1 OCR.

--- a/tests/assets/csv/newspapers/files/flat/1918-12-14/1918-12-14-02.txt
+++ b/tests/assets/csv/newspapers/files/flat/1918-12-14/1918-12-14-02.txt
@@ -1,0 +1,1 @@
+Page 2 OCR.

--- a/tests/assets/csv/newspapers/files/flat/1918-12-14/1918-12-14-03.txt
+++ b/tests/assets/csv/newspapers/files/flat/1918-12-14/1918-12-14-03.txt
@@ -1,0 +1,1 @@
+Page 3 OCR.

--- a/tests/assets/csv/newspapers/files/flat/1918-12-14/1918-12-14-04.txt
+++ b/tests/assets/csv/newspapers/files/flat/1918-12-14/1918-12-14-04.txt
@@ -1,0 +1,1 @@
+Page 4 OCR.


### PR DESCRIPTION
**Github issue**: (#383, #316)

# What does this Pull Request do?

Optionally, makes MIK copy OCR (.txt) files into page-level directories in the CSV Newspapers toolchain.

This PR also includes some cleanup of the CSV newspaper writer class as describe in #316.

# What's new?

If the input directory for jobs using the MIK CSV Newspapers toolchain contain .txt files corresponding to the page master images, like this:


```
1910-01-01
  page-01.tif
  page-01.txt
  page-02.tif
  page-02.txt
```

the .txt files will be copied into the newspaper page-level Islandora ingest packages, like this:

```
├── TT0002
│   ├── 1
│   │   ├── MODS.xml
│   │   ├── OBJ.tif
│   │   └── OCR.txt
│   ├── 2
│   │   ├── MODS.xml
│   │   ├── OBJ.tif
│   │   └── OCR.txt
│   ├── 3
│   │   ├── MODS.xml
│   │   ├── OBJ.tif
│   │   └── OCR.txt
│   ├── 4
│   │   ├── MODS.xml
│   │   ├── OBJ.tif
│   │   └── OCR.txt
│   └── MODS.xml
```

Because this feature introduces a new optional entry in the `[WRITER]datastreams[]` list, we need to provide a new configuration option to indicate that MIK should log missing OCR files when the datastreams list is empty: 

```
[WRITER]
; Default is FALSE
log_missing_ocr_files = TRUE
```

In addition, when `[WRITER]log_missing_ocr_files` is TRUE, the CSV Newspapers input validtor checks for the existence of the .txt files and if any are not found, logs an input validation error.

This PR includes PHPUnit tests for both the CSV Newspapers toolchain and for the CSV Newspapers input validator.

# How should this be tested?

Run PHPUnit tests:

```
phpunit --exclude-group inputvalidators --bootstrap vendor/autoload.php tests
```
should result in "(46 tests, 66 assertions)"
```
phpunit --group inputvalidators --bootstrap vendor/autoload.php tests 
```
should result in "(4 tests, 17 assertions)"

Smoketest:

Using configuration and data files in the attached .zip, do the following:

1. Check out the issue-383 branch
1. Asssuming you have unzipped the file within your mik directory, run `./mik -c issue-383/issue-383.ini -cc all` and then if there are no problems, `./mik -c issue-383/issue-383.ini`

Your output directory should look like this:

```
issue_383_output/
├── input_validator.log
├── mik.log
├── problem_records.log
├── TT0002
│   ├── 1
│   │   ├── MODS.xml
│   │   ├── OBJ.tif
│   │   └── OCR.txt
│   ├── 2
│   │   ├── MODS.xml
│   │   ├── OBJ.tif
│   │   └── OCR.txt
│   ├── 3
│   │   ├── MODS.xml
│   │   ├── OBJ.tif
│   │   └── OCR.txt
│   ├── 4
│   │   ├── MODS.xml
│   │   ├── OBJ.tif
│   │   └── OCR.txt
│   └── MODS.xml
└── TT0003
    ├── 1
    │   ├── MODS.xml
    │   ├── OBJ.tif
    │   └── OCR.txt
    ├── 2
    │   ├── MODS.xml
    │   ├── OBJ.tif
    │   └── OCR.txt
    ├── 3
    │   ├── MODS.xml
    │   ├── OBJ.tif
    │   └── OCR.txt
    ├── 4
    │   ├── MODS.xml
    │   ├── OBJ.tif
    │   └── OCR.txt
    └── MODS.xml
```

MIK only generated two packages because one (TT001) has a missing .txt file. You can verify this by looking at the input validator and problem records log file.

To test that this new feature has no side effects in jobs that do not include page-level .txt files, change the input directory to "issue-383/files_no_text" and comment out the `[WRITER]log_missing_ocr_files` config option. 

[issue-383.zip](https://github.com/MarcusBarnes/mik/files/1036387/issue-383.zip)
