### PR TITLE
Work on #388.

### DIFF
--- a/src/fetchers/Csv.php
+++ b/src/fetchers/Csv.php
@@ -101,6 +101,11 @@ class Csv extends Fetcher
             ->fetchAssoc();
 
             foreach ($records as $index => &$record) {
+                // Commenting out rows only works if the # is the first
+                // character in the record key field.
+                if (preg_match('/^#/', $record[$this->record_key])) {
+                    unset($records[$index]);
+                }
                 if (!is_null($record[$this->record_key]) || strlen($record[$this->record_key])) {
                     $record = (object) $record;
                     $record->key = $record->{$this->record_key};

--- a/tests/assets/csv/sample_metadata.csv
+++ b/tests/assets/csv/sample_metadata.csv
@@ -14,6 +14,7 @@
 "postcard_13","Merritt, B.C.","1914","Merritt, BC","Streets; Storefronts; Pedestrians; Utility poles","A street in Merritt, B.C. Some storefronts and pedestrians are shown.","postcard_13.tif"
 "postcard_14","Aerial View Showing Brockton Point & City, Vancouver, B.C.","1946","Brockton Point, BC; Vancouver, BC","Aerial views; Cities & towns; Bays (Bodies of water); Mountains","Aerial view of Vancouver, B.C. showing Brockton Point. The North Shore Mountains are also shown.","postcard_14.jpg"
 "postcard_15","The Parade - Race Meet, 1941","1946","Williams Lake, BC","Parades & processions; Streets; Horseback riding; Racing","A parade and race meet in Williams Lake, B.C. Numerous people are shown on horseback in the parade.","postcard_15.tif"
+"#postcard_999","My title is 'I am a commented out row'.","","","","",""
 "postcard_16","Parliament Bldgs., Victoria, B.C.","1921","Victoria, BC","Capitols; Trees","British Columbia Parliament Buildings in Victoria, B.C. viewed from behind some trees.","postcard_16.jpg"
 "postcard_17","Wellington Ave., Chilliwack BC.","1947","Chilliwack, BC","Streets; Automobiles; Storefronts; Pedestrians","Wellington Avenue in Chilliwack, B.C. Some automobiles, storefronts and pedestrians are shown.","postcard_17.tif"
 "postcard_18","Bridge At Cultus Lake, Chilliwack, B.C.","1950","Cultus Lake, BC","Lakes & ponds; Bridges","A small bridge over part of Cultus Lake, B.C.","postcard_18.tif"


### PR DESCRIPTION
**Github issue**: (#388)

# What does this Pull Request do?

Adds support for commenting out rows in CSV input files.

# What's new?

A check within the src/fetchers/Csv.php fetcher to filter out any rows that have a `#` at the beginning of the column configured to be the `record_key`. This filtering happens before fetchermanipulators are applied.

# How should this be tested?

This PR can be tested using the proposed "testable" workflow described in #384. The following tests pass on my local copy:

1. In the master branch, run the PHPUnit tests: `phpunit --exclude-group inputvalidators --bootstrap vendor/autoload.php tests`. You should get 46 tests, 66 assertions.
1. Check out the issue-388 branch and rerun the tests. You should get the same results.

This test covers the changed code because the `testGetNumRecs()` test within the CsVFetcherTest.php class continues to pass.

We will need to document how to comment out rows in all of the CSV toolchain wiki pages.

