### PR TITLE
Work on #392.

### DIFF
--- a/mik
+++ b/mik
@@ -317,22 +317,13 @@ foreach ($records as $record) {
 
 // Run any shutdown hooks.
 if (isset($settings['WRITER']['shutdownhooks'])) {
+  echo PHP_EOL; 
   foreach ($settings['WRITER']['shutdownhooks'] as $hook) {
     $cmd = sprintf("%s %s", $hook, realpath($configPath));
-
-    echo "Running shutdown hook # $hook";
-    $process = new BackgroundProcess($cmd);
-    $process->run();
-
-    // Make sure that each hook completes
-    // before starting the next one.
-    // https://packagist.org/packages/cocur/background-process
-    while ($process->isRunning()) {
-      echo '.';
-      sleep(1);
-    }
-    echo "\n";
+    echo "Running shutdown hook # $hook" . PHP_EOL;
+    exec($cmd);
   }
+  echo PHP_EOL; 
 }
 
 


### PR DESCRIPTION
**Github issue**: (#392)

# What does this Pull Request do?

Changes shutdown hook scripts from running in the background to running in the foreground.

# What's new?

As per the discussion in #392, we can't think of any reason to have shutdown hook scripts run as background processes. This PR replaces the code that allowed the scripts to run as a background process with a simple PHP `exec()` call.

# How should this be tested?

This PR requires a smoke test; there are no PHPUnit tests to cover it.

To test:

1. Check out the issue-392 branch.
1. Unzip the attached file into your /tmp directory.
1. Move (`mv`) all the files in the unzipped directory starting with `issue-392*` into your mik directory.
1. Run `./mik -c issue-392.ini`. You should see the following ouput:

```
./mik -c issue-392.ini
Commencing MIK.
Creating 5 Islandora ingest packages. Please be patient.
====================================================================================================> 100%
Running shutdown hook # ./issue-392-script1.sh
Running shutdown hook # ./issue-392-script2.sh
Done. Output packages are in /tmp/issue_392_output. Log is at /tmp/issue_392_output/mik.log
```

and your /tmp/directory should contain a file `/tmp/hey.txt`.

# Additional Notes

We will need to update https://github.com/MarcusBarnes/mik/wiki/Shutdown-hooks.

# Interested parties

@jpeak5 @MarcusBarnes 
