### PR TITLE
Work on #397.

### DIFF
--- a/extras/scripts/samplecontentgenerator/generate.php
+++ b/extras/scripts/samplecontentgenerator/generate.php
@@ -31,16 +31,23 @@ $cmd->option('content_model')
         return in_array($cmodel, $cmodels);
     });
 $cmd->option('ini_template_name')
-    ->aka('t')
-    ->describedAs('.ini template filename. File must exist in the extras/scripts/samplecontentgenerator directory. Derault is "metadata.twig".')
+    ->aka('it')
+    ->describedAs('.ini template filename. File must exist in the extras/scripts/samplecontentgenerator directory. ' .
+      'Default is "metadata.twig".')
     ->default('ini.twig');
 $cmd->option('metadata_template_name')
     ->aka('mt')
-    ->describedAs('Metadata file template filename. File must exist in the extras/scripts/samplecontentgenerator directory. Derault is "metadata.twig".')
-    ->default('ini.twig');
+    ->describedAs('Metadata file template filename. File must exist in the extras/scripts/samplecontentgenerator directory. ' .
+    'Default is "metadata.twig".')
+    ->default('metadata.twig');
+$cmd->option('mappings_file')
+    ->aka('mf')
+    ->describedAs('Mappings file filename. File must exist in the extras/scripts/samplecontentgenerator directory. ' .
+    'Default is "mappings.csv".')
+    ->default('metadata.twig');
 $cmd->option()
     ->require(true)
-    ->describedAs('Ablsolute or relative path to the directory to save the sample data to. Trailing slash is optional.');
+    ->describedAs('Absolute or relative path to the directory to save the sample data to. Trailing slash is optional.');
 
 $output_dir = trim(rtrim($cmd[0]));
 @mkdir($output_dir);
@@ -89,7 +96,7 @@ $metadata_path = $output_dir . DIRECTORY_SEPARATOR . $cmd['sample_id'] . '_metad
 
 file_put_contents($ini_path, $ini_content);
 file_put_contents($metadata_path, $metadata_content);
-copy('extras/scripts/samplecontentgenerator/mappings.csv', $output_dir . DIRECTORY_SEPARATOR . $cmd['sample_id'] . '_mappings.csv');
+copy('extras/scripts/samplecontentgenerator/' . $cmd['mappings_file'], $output_dir . DIRECTORY_SEPARATOR . $cmd['sample_id'] . '_mappings.csv');
 
 generate_sample_object_input($output_dir, $cmd['sample_id'], $cmd['content_model']);
 
@@ -115,13 +122,31 @@ function get_metadata_values($cmodel) {
             'filename5' => 'file5.jpg',
         );
     }
-    else{
+    elseif ($cmodel == 'compound') {
         return $metadata_values = array(
-            'filename1' => 'dir1',
-            'filename2' => 'dir2',
-            'filename3' => 'dir3',
-            'filename4' => 'dir4',
-            'filename5' => 'dir5',
+            'filename1' => 'compoundobject1',
+            'filename2' => 'compoundobject2',
+            'filename3' => 'compoundobject3',
+            'filename4' => 'compoundobject4',
+            'filename5' => 'compoundobject5',
+        );
+    }
+    elseif ($cmodel == 'books') {
+        return $metadata_values = array(
+            'filename1' => 'book1',
+            'filename2' => 'book2',
+            'filename3' => 'book3',
+            'filename4' => 'book4',
+            'filename5' => 'book5',
+        );
+    }
+    elseif ($cmodel == 'newspapers') {
+        return $metadata_values = array(
+            'filename1' => '1920-06-01',
+            'filename2' => '1920-06-02',
+            'filename3' => '1920-06-03',
+            'filename4' => '1920-06-04',
+            'filename5' => '1920-06-05',
         );
     }
 }
@@ -166,7 +191,7 @@ function generate_sample_object_input($output_dir, $sample_id, $cmodel) {
  *
  * @param
  *   $output_dir string
- *      The output directoty path passed in on the command line.
+ *      The output directory path passed in on the command line.
  *   $records array
  *      The list of metadata records parsed from the sample metadata CSV file.
  */
@@ -184,13 +209,21 @@ function generate_single_object_files($output_dir, $records) {
  *
  * @param
  *   $output_dir string
- *      The output directoty path passed in on the command line.
+ *      The output directory path passed in on the command line.
  *   $records array
  *      The list of metadata records parsed from the sample metadata CSV file.
  */
 function generate_compound_object_files($output_dir, $records) {
-    echo "Generating compound object sample data is not available yet\n";
-    exit;
+    foreach($records as $row) {
+        $record = explode(',', $row);
+        $dirname = trim($record[1], '"');
+        $compound_object_dir = $output_dir . DIRECTORY_SEPARATOR . $dirname;
+        mkdir($compound_object_dir);
+        $child_filenames = array('image_01.tif', 'image_02.tif');
+        foreach ($child_filenames as $filename) {
+            file_put_contents($compound_object_dir . DIRECTORY_SEPARATOR . $filename, "fake content"); 
+        }
+    }
 }
 
 /**
@@ -198,13 +231,21 @@ function generate_compound_object_files($output_dir, $records) {
  *
  * @param
  *   $output_dir string
- *      The output directoty path passed in on the command line.
+ *      The output directory path passed in on the command line.
  *   $records array
  *      The list of metadata records parsed from the sample metadata CSV file.
  */
 function generate_book_object_files($output_dir, $records) {
-    echo "Generating book sample data is not available yet\n";
-    exit;
+    foreach($records as $row) {
+        $record = explode(',', $row);
+        $dirname = trim($record[1], '"');
+        $book_object_dir = $output_dir . DIRECTORY_SEPARATOR . $dirname;
+        mkdir($book_object_dir);
+        $page_filenames = array('page-01.tif', 'page-02.tif', 'page-03.tif');
+        foreach ($page_filenames as $filename) {
+            file_put_contents($book_object_dir . DIRECTORY_SEPARATOR . $filename, "fake content"); 
+        }
+    }
 }
 
 /**
@@ -212,11 +253,19 @@ function generate_book_object_files($output_dir, $records) {
  *
  * @param
  *   $output_dir string
- *      The output directoty path passed in on the command line.
+ *      The output directory path passed in on the command line.
  *   $records array
  *      The list of metadata records parsed from the sample metadata CSV file.
  */
 function generate_newspaper_object_files($output_dir, $records) {
-    echo "Generating newspaper sample data is not available yet\n";
-    exit;
+    foreach($records as $row) {
+        $record = explode(',', $row);
+        $dirname = trim($record[1], '"');
+        $issue_object_dir = $output_dir . DIRECTORY_SEPARATOR . $dirname;
+        mkdir($issue_object_dir);
+        $page_filenames = array('page-01.tif', 'page-02.tif', 'page-03.tif');
+        foreach ($page_filenames as $filename) {
+            file_put_contents($issue_object_dir . DIRECTORY_SEPARATOR . $filename, "fake content"); 
+        }
+    }
 }

--- a/extras/scripts/samplecontentgenerator/generate.php
+++ b/extras/scripts/samplecontentgenerator/generate.php
@@ -44,7 +44,7 @@ $cmd->option('mappings_file')
     ->aka('mf')
     ->describedAs('Mappings file filename. File must exist in the extras/scripts/samplecontentgenerator directory. ' .
     'Default is "mappings.csv".')
-    ->default('metadata.twig');
+    ->default('mappings.csv');
 $cmd->option()
     ->require(true)
     ->describedAs('Absolute or relative path to the directory to save the sample data to. Trailing slash is optional.');

--- a/extras/scripts/samplecontentgenerator/generate.php
+++ b/extras/scripts/samplecontentgenerator/generate.php
@@ -13,9 +13,6 @@
 
 require 'vendor/autoload.php';
 
-use \Commando;
-use \Twig\Twig;
-
 $cmd = new \Commando\Command();
 $cmd->option('sample_id')
     ->aka('id')

--- a/extras/scripts/samplecontentgenerator/ini.twig
+++ b/extras/scripts/samplecontentgenerator/ini.twig
@@ -15,6 +15,9 @@ class = Csv
 input_file = "{{ sample_id }}_metadata.csv"
 temp_directory = "{{ output_path }}_temp"
 record_key = Identifier
+{% if class == 'CsvCompound' %}
+child_key = Childkey
+{% endif %}
 
 [METADATA_PARSER]
 class = mods\CsvToMods
@@ -29,12 +32,12 @@ file_name_field = File
 
 [WRITER]
 class = {{ class }}
-output_directory = "{{ output_path }}"
+output_directory = "{{ output_path }}_output"
 
 [MANIPULATORS]
 metadatamanipulators[] = "SplitRepeatedValues|Subjects|/subject/topic|;"
 
 [LOGGING]
-path_to_log = "{{ output_path }}/mik.log"
-path_to_manipulator_log= "{{ output_path }}/manipulator.log"
+path_to_log = "{{ output_path }}_output/mik.log"
+path_to_manipulator_log= "{{ output_path }}_output/manipulator.log"
 {% endautoescape %}

--- a/extras/scripts/samplecontentgenerator/ini.twig
+++ b/extras/scripts/samplecontentgenerator/ini.twig
@@ -39,6 +39,9 @@ class = {{ class }}
 {% if class != 'CsvSingleFile' %}
 metadata_filename = "MODS.xml"
 {% endif %}
+{% if class == 'CsvCompound' %}
+child_title = "%parent_title%, part %sequence_number%"
+{% endif %}
 output_directory = "{{ output_path }}_output"
 
 [MANIPULATORS]

--- a/extras/scripts/samplecontentgenerator/ini.twig
+++ b/extras/scripts/samplecontentgenerator/ini.twig
@@ -28,7 +28,11 @@ repeatable_wrapper_elements[] = subject
 class = {{ class }}
 input_directory = "{{ output_path }}"
 temp_directory = "{{ output_path }}_temp"
+{% if class == 'CsvCompound' %}
+compound_directory_field = File
+{% else %}
 file_name_field = File
+{% endif %}
 
 [WRITER]
 class = {{ class }}

--- a/extras/scripts/samplecontentgenerator/ini.twig
+++ b/extras/scripts/samplecontentgenerator/ini.twig
@@ -36,6 +36,9 @@ file_name_field = File
 
 [WRITER]
 class = {{ class }}
+{% if class != 'CsvSingleFile' %}
+metadata_filename = "MODS.xml"
+{% endif %}
 output_directory = "{{ output_path }}_output"
 
 [MANIPULATORS]

--- a/extras/scripts/samplecontentgenerator/metadata.twig
+++ b/extras/scripts/samplecontentgenerator/metadata.twig
@@ -1,6 +1,6 @@
-Identifier,File,Title,Creator,Date taken,Subjects,Note
-"id_01","{{ filename1 }}","Small boats in Havana Harbour","Jordan, Mark","2015-03-08","Boats; water","Taken on vacation in Cuba."
-"id_02","{{ filename2 }}","Manhatten Island","Jordan, Mark","2015-09-13","Cityscapes","Taken from the ferry from downtown New York to Highlands, NJ. Weather was windy."
-"id_03","{{ filename3 }}","Looking across Burrard Inlet","Jordan, Mark","2011-08-01",,"View from Deep Cove to Burnaby Mountain. Simon Fraser University is visible on the top of the mountain in the distance."
-"id_04","{{ filename4 }}","Amsterdam waterfront","Jordan, Mark","2013-01-17",,"Amsterdam waterfront on an overcast day."
-"id_05","{{ filename5 }}","Alcatraz Island","Jordan, Mark","2014-01-14","Alcatraz Federal Penitentiary; islands","Taken from Fisherman's Wharf, San Francisco."
+Identifier,File{% if filename1 matches '/^compound/' %},Childkey{% endif %},Title,Creator,Date taken,Subjects,Note
+"id_01","{{ filename1 }}"{% if filename1 matches '/^compound/' %},""{% endif %},"Small boats in Havana Harbour","Jordan, Mark","2015-03-08","Boats; water","Taken on vacation in Cuba."
+"id_02","{{ filename2 }}"{% if filename2 matches '/^compound/' %},""{% endif %},"Manhatten Island","Jordan, Mark","2015-09-13","Cityscapes","Taken from the ferry from downtown New York to Highlands, NJ. Weather was windy."
+"id_03","{{ filename3 }}"{% if filename3 matches '/^compound/' %},""{% endif %},"Looking across Burrard Inlet","Jordan, Mark","2011-08-01",,"View from Deep Cove to Burnaby Mountain. Simon Fraser University is visible on the top of the mountain in the distance."
+"id_04","{{ filename4 }}"{% if filename4 matches '/^compound/' %},""{% endif %},"Amsterdam waterfront","Jordan, Mark","2013-01-17",,"Amsterdam waterfront on an overcast day."
+"id_05","{{ filename5 }}"{% if filename5 matches '/^compound/' %},""{% endif %},"Alcatraz Island","Jordan, Mark","2014-01-14","Alcatraz Federal Penitentiary; islands","Taken from Fisherman's Wharf, San Francisco."


### PR DESCRIPTION
**Github issue**: (#397)

#393 is also relevant.

# What does this Pull Request do?

Adds the ability to generate sample MIK configurations and input data for CSV compound, CSV books, and CVS newspaper issues.

# What's new?

Just completing work started in PR #395.

# How should this be tested?

This PR needs to be tested using a smoke test. There are no PHPUnit tests for this PR. To test it, for each of the content models, run `generate.php` from within the MIK directory and run `tree` on the output directory:

`mik>php extras/scripts/samplecontentgenerator/generate.php -id single-test /tmp/single`

```
/tmp/single/
├── file1.jpg
├── file2.jpg
├── file3.jpg
├── file4.jpg
├── file5.jpg
├── single-test.ini
├── single-test_mappings.csv
└── single-test_metadata.csv
```

`mik>php extras/scripts/samplecontentgenerator/generate.php -m compound -id compound-test /tmp/compound`

```
/tmp/compound/
├── compoundobject1
│   ├── image_01.tif
│   └── image_02.tif
├── compoundobject2
│   ├── image_01.tif
│   └── image_02.tif
├── compoundobject3
│   ├── image_01.tif
│   └── image_02.tif
├── compoundobject4
│   ├── image_01.tif
│   └── image_02.tif
├── compoundobject5
│   ├── image_01.tif
│   └── image_02.tif
├── compound-test.ini
├── compound-test_mappings.csv
└── compound-test_metadata.csv
```

Note that /tmp/compound/compound-test.ini contains the required compound_directory_field, child_title, metadata_filename, and child_key settings.


`mik>php extras/scripts/samplecontentgenerator/generate.php -m books -id book-test /tmp/books`

```
/tmp/books/
├── book1
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── book2
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── book3
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── book4
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── book5
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── book-test.ini
├── book-test_mappings.csv
└── book-test_metadata.csv
```

`mik>php extras/scripts/samplecontentgenerator/generate.php -m newspapers -id newspapers-test /tmp/newspapers`

```
/tmp/newspapers/
├── 1920-06-01
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── 1920-06-02
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── 1920-06-03
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── 1920-06-04
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── 1920-06-05
│   ├── page-01.tif
│   ├── page-02.tif
│   └── page-03.tif
├── newspapers-test.ini
├── newspapers-test_mappings.csv
└── newspapers-test_metadata.csv
```

# Interested parties

@MarcusBarnes 
