### PR TITLE
Issue 40 (incl. work on issues 365 and 25) - clean up of MODS metadata parser code

### DIFF
--- a/src/metadataparsers/mods/CdmToMods.php
+++ b/src/metadataparsers/mods/CdmToMods.php
@@ -12,7 +12,7 @@ class CdmToMods extends Mods
      * to MODS XML mapping.
      */
     public $collectionMappingArray;
-    
+
     /**
      *  @var array $CONTENTdmFieldValuesArray array with field values of proper name
      *  as $keys rather than 'nick' keys.
@@ -40,13 +40,13 @@ class CdmToMods extends Mods
      *   metadatamanipulator_class_name|param_0|param_1|...|param_n
      */
     public $metadatamanipulators;
-    
+
     /**
      * @var array $repeatableWrapperElements - array of wrapper elements
      *that can be repeated (not consolidated) set in the config.
      */
     public $repeatableWrapperElements;
-    
+
     /**
      * @var object $fetcher fetcher object for access to public methods as needed.
      */
@@ -129,7 +129,7 @@ class CdmToMods extends Mods
         $modsOpeningTag .= 'xmlns:mods="http://www.loc.gov/mods/v3" ';
         $modsOpeningTag .= 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ';
         $modsOpeningTag .= 'xmlns:xlink="http://www.w3.org/1999/xlink">';
-        
+
         foreach ($collectionMappingArray as $key => $valueArray) {
             if (preg_match('/^#/', $valueArray[0])) {
               continue;
@@ -201,14 +201,14 @@ class CdmToMods extends Mods
         }
 
         $modsString = $modsOpeningTag . '</mods>';
-        
+
         $modsString = $this->oneParentWrapperElement($modsString);
 
         $doc = new \DomDocument('1.0');
         $doc->loadXML($modsString, LIBXML_NSCLEAN);
         $doc->formatOutput = true;
         $modsxml = $doc->saveXML();
-        
+
         return $modsxml;
     }
 
@@ -227,7 +227,7 @@ class CdmToMods extends Mods
         $modsOpeningTag .= 'xmlns:xlink="http://www.w3.org/1999/xlink">';
 
         $modsOpeningTag .= '<titleInfo><title>' . $page_title . '</title></titleInfo>';
- 
+
         $includeMigratedFromUri = $this->includeMigratedFromUri;
         $collectionAlias = $this->alias;
         if ($includeMigratedFromUri == true) {
@@ -256,279 +256,8 @@ class CdmToMods extends Mods
         $doc->loadXML($modsString, LIBXML_NSCLEAN);
         $doc->formatOutput = true;
         $modsxml = $doc->saveXML();
-        
+
         return $modsxml;
-    }
-
-
-    /**
-     *  Takes MODS XML string and returns an array the unique element 
-     *  signature strings of the child elements.
-     *
-     *  @param string $xmlString An MODS XML string.
-     *
-     *  @return array of unique child node element signature strings.
-     */
-    private function getChildNodesFromModsXMLString($xmlString)
-    {
-        $xml = new \DomDocument();
-        $xml->loadXML($xmlString);
-
-        //$elementSignature = array($elementName, $elementAttributesMap);
-        //$this->signatureToString($elementSignature); 
-
-
-        $childNodesElementSignatureStringArray = array();
-        foreach ($xml->documentElement->childNodes as $node) {
-            $elementName = $node->nodeName;
-            
-            $elementAttributesMap = array();
-            $attributesNodeMap = $node->attributes;
-            $len = $attributesNodeMap->length;
-            for($i = 0 ; $i < $len; ++$i) {
-                $attributeItem = $attributesNodeMap->item($i);
-                $attributeName = $attributeItem->name;
-                $attributeValue = $attributeItem->value;
-                $elementAttributesMap[$attributeName] = $attributeValue;
-            }            
-            $elementSignature = array($elementName, $elementAttributesMap);
-            
-            $childNodesElementSignatureArray[] = $this->signatureToString($elementSignature);
-        }
-
-        $returnArray = array_unique($childNodesElementSignatureArray);
-
-        return $returnArray;
-    }
-
-    /**
-     * Determine which child elements of MODS root element are wrapper elements:
-     *  1) They have child elements of type XML_ELEMENT_NODE (Value: 1)
-     *
-     * @param $xml object MODS XML object
-     *
-     * @param $uniqueChildNodeSignatureArray an array that lists the unique element 
-     * signatures of children of the root MOD element.
-     *
-     * @return arrry of XML elemets that are wrapper elements (children of root element).
-     */
-    private function determineRepeatedWrapperChildElements($xml, $uniqueChildNodeSignatureArray)
-    {
-        $wrapperDomNodes = array();
-        // Grab the elements
-        foreach ($uniqueChildNodeSignatureArray as $nodeSignatureString) {
-            
-            // turn node signature string into parts element name + element attributes
-            $nodeSignature = $this->elementSignatureFromString($nodeSignatureString);
-            
-            $nodeName = $nodeSignature[0];
-            $nodeAttributes = $nodeSignature[1];
-            //DOMNodeList
-            $nodeListObj = $xml->getElementsByTagName($nodeName);
-            if ($nodeListObj->length >= 2 && !in_array($nodeName, $this->repeatableWrapperElements)) {
-                
-                // The element name appears more than once and 
-                // is not set as an allowed repeatable wrapper element.
-                foreach ($nodeListObj as $node) {
-                    if ($node->hasChildNodes() /*&& !$node->hasAttributes()*/) {
-                        foreach ($node->childNodes as $childNode) {
-                            if ($childNode->nodeType == XML_ELEMENT_NODE) {
-                                $wrapperDomNodes[] = $node;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return $wrapperDomNodes;
-
-    }
-
-    /**
-     * If a (parent) wrapper element more than once, consolidate the child nodes
-     * into only one parent wrapper element and return the consolidated elements.
-     *
-     * @param array $wrapperElementArray An array of wrapper elements.
-     *
-     * @return array An array of consolidated wrapper elements of type XML_ELEMENT_NODE
-     */
-    private function consolidateWrapperElements($wrapperElementArray)
-    {
-        $consolidatedWrapperElementsArray = array();
-        $elementNameTrackingArray = array();
-        $elementSignatureTrackingArray = array();
-        foreach ($wrapperElementArray as $wrapperElement) {
-            $name = $wrapperElement->nodeName;
-            $attributesNodeMap = $wrapperElement->attributes;
-            $length = $attributesNodeMap->length;
-            for($i=0; $i < $length; ++$i){            
-               $attributeItem = $attributesNodeMap->item($i);
-               $attributeName = $attributeItem->name;
-               $attributeValue = $attributeItem->value;
-            }
-
-            $elementName = $wrapperElement->nodeName;
-            // store elements attributes (with values) in hashed array
-            // array('attributeName' =? 'attributeValue')
-            $elementAttributesMap = array();
-            $attributesNodeMap = $wrapperElement->attributes;
-            $len = $attributesNodeMap->length;
-            for($i = 0 ; $i < $len; ++$i) {
-                $attributeItem = $attributesNodeMap->item($i);
-                $attributeName = $attributeItem->name;
-                $attributeValue = $attributeItem->value;
-                $elementAttributesMap[$attributeName] = $attributeValue;
-            }
-            // dev - rather than just check element name, check element name
-            // and element attributes.
-            $elementSignature = array($elementName, $elementAttributesMap);
-            
-            if (in_array($elementSignature, $elementSignatureTrackingArray)) {
-                // $elementName is already in the tracking array
-                // push the element's childnodes to the end of the array.
-                $keyFromSignature = $this->signatureToString($elementSignature); 
-                array_push($elementNameTrackingArray[$keyFromSignature], $wrapperElement->childNodes);
-            } else {
-                // $elementSignature is not in the tracking array, add it.
-                array_push($elementSignatureTrackingArray, $elementSignature);
-
-                $keyFromSignature = $this->signatureToString($elementSignature);   
-                 // $elementName is not in the tracking array, add it.
-                $elementNameTrackingArray[$keyFromSignature] = array($wrapperElement->childNodes);
-            }
-        }
-
-        return $elementNameTrackingArray;
-    }
-
-
-    /**
-     * Turns an signature to a string for use 
-     */
-    private function signatureToString($elementSignature)
-    {   
-
-        $signatureString = $elementSignature[0];
-
-        $attributesKeyValuesArray = $elementSignature[1];
-        
-        if(count($attributesKeyValuesArray) > 0){
-
-            $signatureString .=  "?";
-
-            foreach($attributesKeyValuesArray as $key => $value) {
-
-               $signatureString .= $key . "=" . $value . "|";
-            }
-        }
-        
-        return $signatureString;  
-        
-    }
-
-    /**
-     * Checks an XML string for common parent wrapper elements
-     * and uses only one as appropriate.
-     *
-     * @param string $xmlString
-     *     An XML snippet that can be turned into a valid XML document.
-     *
-     * @return string
-     *     An XML snippet that can be turned into a valid XML docuement
-     *     and which can be validated successfully against an XML schema
-     *     such as MODS.
-     */
-    private function oneParentWrapperElement($xmlString)
-    {
-
-        $xml = new \DomDocument();
-        $xml->loadXML($xmlString);
-
-        // Unique names of element nodes that are children of MODS root element.
-        // array returned is is the list of unique child element signatures 
-        // (that is, keeps track of attributes)
-        $uniqueChildNodeSignatureArray = $this->getChildNodesFromModsXMLString($xmlString);
-
-        // Determine which child elements of MODS root element are wrapper elements:
-        //  1) They have child elements of type XML_ELEMENT_NODE (Value: 1)
-        $wrapperElementArray =
-          $this->determineRepeatedWrapperChildElements($xml, $uniqueChildNodeSignatureArray);
-
-        // remove repeated wrapper nodes.        
-        foreach ($wrapperElementArray as $wrapperElement) {
-            $deleteThisNode = $wrapperElement;
-            if (isset($deleteThisNode->parentNode)) {
-                $parentNode = $deleteThisNode->parentNode;
-                $parentNode->removeChild($deleteThisNode);
-                $xml->saveXML($parentNode);
-            }
-        }
-        
-        // consolidate nodes with one wrapper
-        $consolidatedRepeatedWrapperElements =
-          $this->consolidateWrapperElements($wrapperElementArray);
-
-        // Add nodes back into $xml document.
-        $modsElement = $xml->getElementsByTagName('mods')->item(0);
-        foreach ($consolidatedRepeatedWrapperElements as $key => $valueArray) {
-            // $elementSignature array(elementName, array(attributeName=>attributeKey))
-            $elementSignature = $this->elementSignatureFromString($key);
-            $elementName = $elementSignature[0];
-            $elementAttributes = $elementSignature[1];
-
-            //$wrapperElement = $xml->createElement($key);
-            $wrapperElement = $xml->createElementNS('http://www.loc.gov/mods/v3', $elementName);
-            if(!empty($elementAttributes)){
-                // add attributes and values
-                foreach($elementAttributes as $key => $value) {
-                    $wrapperElement->setAttribute($key, $value);
-                }
-
-            }
-
-            foreach ($valueArray as $nodes) {
-                foreach ($nodes as $node) {
-                    $wrapperElement->appendChild($node);
-                }
-            }
-            $modsElement->appendChild($wrapperElement);
-            
-        }
-
-        $xmlString = $xml->saveXML();
-        return $xmlString;
-
-    }
-
-    /**
-     * Turn elementSignatureString into element name and attributes (with values)
-     * @param string $elementSignatureString example elementName?attribute0=value0|attribute1=value1|attribute2=value2
-     * @return array [elementNmae, array(attribute0=>value0, attribute1=value1, attribute2=value2, )]
-     */
-    private function elementSignatureFromString($elementSignatureString){
-
-            $elementNameAttributesArray = explode('?', $elementSignatureString);
-
-            $elementName = $elementNameAttributesArray[0];
-            
-            $elementAttributeKeyValueArray = array();
-            if(count($elementNameAttributesArray) > 1){
-                // element has attributes.
-                $elementAttributesArray = explode('|', $elementNameAttributesArray[1]);
-                // remove empty, false, or null values from the array.
-                $elementAttributesArray = array_filter($elementAttributesArray);
-                foreach($elementAttributesArray as $attributeValue){
-                    $attributeValuePair = explode('=', $attributeValue);
-                    $attributeName = $attributeValuePair[0];
-                    $attributeValue = $attributeValuePair[1];
-                    $elementAttributeKeyValueArray[$attributeName] = $attributeValue;
-
-                }
-            }
-             
-            return array($elementName, $elementAttributeKeyValueArray);
-    
     }
 
     /**

--- a/src/metadataparsers/mods/CsvToMods.php
+++ b/src/metadataparsers/mods/CsvToMods.php
@@ -1,5 +1,5 @@
 <?php
-// src/metadataparsers/mods/CdmToMods.php
+// src/metadataparsers/mods/CsvToMods.php
 
 namespace mik\metadataparsers\mods;
 
@@ -22,16 +22,16 @@ class CsvToMods extends Mods
      * @var array $metadatamanipulators - array of metadatamanimpulors from config.
      */
     public $metadatamanipulators;
-    
+
     /**
-     * @var array $repeatableWrapperElements - array of wrapper elements 
+     * @var array $repeatableWrapperElements - array of wrapper elements
      *that can be repeated (not consolidated) set in the config.
      */
     public $repeatableWrapperElements;
 
     /**
      * Create a new Metadata Instance
-     * @param path to CSV file containing the Cdm to Mods mapping info.
+     * @param path to CSV file containing the CSV to Mods mapping info.
      */
     public function __construct($settings)
     {
@@ -79,14 +79,14 @@ class CsvToMods extends Mods
     {
         $record_key_column = $this->record_key;
         $record_key = $objectInfo->$record_key_column;
-        
+
         $modsString = '';
 
         $modsOpeningTag = '<mods xmlns="http://www.loc.gov/mods/v3" ';
         $modsOpeningTag .= 'xmlns:mods="http://www.loc.gov/mods/v3" ';
         $modsOpeningTag .= 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ';
         $modsOpeningTag .= 'xmlns:xlink="http://www.w3.org/1999/xlink">';
-        
+
         foreach ($collectionMappingArray as $field => $fieldMappings) {
             if (preg_match('/^#/', $fieldMappings[0])) {
               continue;
@@ -101,7 +101,7 @@ class CsvToMods extends Mods
                 // Special source field name for mappings to static snippets
                 $fiedlValue = '';
             } else {
-                // Log mismatch between mapping file and source fields (e.g., CDM)
+                // Log mismatch between mapping file and source CSV fields.
                 $logMessage = "Mappings file contains a row that ";
                 $logMessage .= "is not in source CSV row for this object.";
                 $this->log->addWarning($logMessage, array('Record key' => $record_key,
@@ -138,8 +138,6 @@ class CsvToMods extends Mods
                 $pattern = '/%value%/';
                 $xmlSnippet = preg_replace($pattern, $fieldValue, $xmlSnippet);
                 $modsOpeningTag .= $xmlSnippet;
-            } else {
-                // Determine if we need to store the CONTENTdm_field as an identifier.
             }
         }
 
@@ -156,278 +154,8 @@ class CsvToMods extends Mods
     }
 
     /**
-     *  Takes MODS XML string and returns an array the unique element 
-     *  signature strings of the child elements.
-     *
-     *  @param string $xmlString An MODS XML string.
-     *
-     *  @return array of unique child node element signature strings.
-     */
-    private function getChildNodesFromModsXMLString($xmlString)
-    {
-        $xml = new \DomDocument();
-        $xml->loadXML($xmlString);
-
-        //$elementSignature = array($elementName, $elementAttributesMap);
-        //$this->signatureToString($elementSignature); 
-
-
-        $childNodesElementSignatureStringArray = array();
-        foreach ($xml->documentElement->childNodes as $node) {
-            $elementName = $node->nodeName;
-            
-            $elementAttributesMap = array();
-            $attributesNodeMap = $node->attributes;
-            $len = $attributesNodeMap->length;
-            for($i = 0 ; $i < $len; ++$i) {
-                $attributeItem = $attributesNodeMap->item($i);
-                $attributeName = $attributeItem->name;
-                $attributeValue = $attributeItem->value;
-                $elementAttributesMap[$attributeName] = $attributeValue;
-            }            
-            $elementSignature = array($elementName, $elementAttributesMap);
-            
-            $childNodesElementSignatureArray[] = $this->signatureToString($elementSignature);
-        }
-
-        $returnArray = array_unique($childNodesElementSignatureArray);
-
-        return $returnArray;
-    }
-
-    /**
-     * Determine which child elements of MODS root element are wrapper elements:
-     *  1) They have child elements of type XML_ELEMENT_NODE (Value: 1)
-     *
-     * @param $xml object MODS XML object
-     *
-     * @param $uniqueChildNodeSignatureArray an array that lists the unique element 
-     * signatures of children of the root MOD element.
-     *
-     * @return arrry of XML elemets that are wrapper elements (children of root element).
-     */
-    private function determineRepeatedWrapperChildElements($xml, $uniqueChildNodeSignatureArray)
-    {
-        $wrapperDomNodes = array();
-        // Grab the elements
-        foreach ($uniqueChildNodeSignatureArray as $nodeSignatureString) {
-            
-            // turn node signature string into parts element name + element attributes
-            $nodeSignature = $this->elementSignatureFromString($nodeSignatureString);
-            
-            $nodeName = $nodeSignature[0];
-            $nodeAttributes = $nodeSignature[1];
-            //DOMNodeList
-            $nodeListObj = $xml->getElementsByTagName($nodeName);
-            if ($nodeListObj->length >= 2 && !in_array($nodeName, $this->repeatableWrapperElements)) {
-                
-                // The element name appears more than once and 
-                // is not set as an allowed repeatable wrapper element.
-                foreach ($nodeListObj as $node) {
-                    if ($node->hasChildNodes() /*&& !$node->hasAttributes()*/) {
-                        foreach ($node->childNodes as $childNode) {
-                            if ($childNode->nodeType == XML_ELEMENT_NODE) {
-                                $wrapperDomNodes[] = $node;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return $wrapperDomNodes;
-
-    }
-
-    /**
-     * If a (parent) wrapper element more than once, consolidate the child nodes
-     * into only one parent wrapper element and return the consolidated elements.
-     *
-     * @param array $wrapperElementArray An array of wrapper elements.
-     *
-     * @return array An array of consolidated wrapper elements of type XML_ELEMENT_NODE
-     */
-    private function consolidateWrapperElements($wrapperElementArray)
-    {
-        $consolidatedWrapperElementsArray = array();
-        $elementNameTrackingArray = array();
-        $elementSignatureTrackingArray = array();
-        foreach ($wrapperElementArray as $wrapperElement) {
-            $name = $wrapperElement->nodeName;
-            $attributesNodeMap = $wrapperElement->attributes;
-            $length = $attributesNodeMap->length;
-            for($i=0; $i < $length; ++$i){            
-               $attributeItem = $attributesNodeMap->item($i);
-               $attributeName = $attributeItem->name;
-               $attributeValue = $attributeItem->value;
-            }
-
-            $elementName = $wrapperElement->nodeName;
-            // store elements attributes (with values) in hashed array
-            // array('attributeName' =? 'attributeValue')
-            $elementAttributesMap = array();
-            $attributesNodeMap = $wrapperElement->attributes;
-            $len = $attributesNodeMap->length;
-            for($i = 0 ; $i < $len; ++$i) {
-                $attributeItem = $attributesNodeMap->item($i);
-                $attributeName = $attributeItem->name;
-                $attributeValue = $attributeItem->value;
-                $elementAttributesMap[$attributeName] = $attributeValue;
-            }
-            // dev - rather than just check element name, check element name
-            // and element attributes.
-            $elementSignature = array($elementName, $elementAttributesMap);
-            
-            if (in_array($elementSignature, $elementSignatureTrackingArray)) {
-                // $elementName is already in the tracking array
-                // push the element's childnodes to the end of the array.
-                $keyFromSignature = $this->signatureToString($elementSignature); 
-                array_push($elementNameTrackingArray[$keyFromSignature], $wrapperElement->childNodes);
-            } else {
-                // $elementSignature is not in the tracking array, add it.
-                array_push($elementSignatureTrackingArray, $elementSignature);
-
-                $keyFromSignature = $this->signatureToString($elementSignature);   
-                 // $elementName is not in the tracking array, add it.
-                $elementNameTrackingArray[$keyFromSignature] = array($wrapperElement->childNodes);
-            }
-        }
-
-        return $elementNameTrackingArray;
-    }
-
-
-    /**
-     * Turns an signature to a string for use 
-     */
-    private function signatureToString($elementSignature)
-    {   
-
-        $signatureString = $elementSignature[0];
-
-        $attributesKeyValuesArray = $elementSignature[1];
-        
-        if(count($attributesKeyValuesArray) > 0){
-
-            $signatureString .=  "?";
-
-            foreach($attributesKeyValuesArray as $key => $value) {
-
-               $signatureString .= $key . "=" . $value . "|";
-            }
-        }
-        
-        return $signatureString;  
-        
-    }
-
-    /**
-     * Checks an XML string for common parent wrapper elements
-     * and uses only one as appropriate.
-     *
-     * @param string $xmlString
-     *     An XML snippet that can be turned into a valid XML document.
-     *
-     * @return string
-     *     An XML snippet that can be turned into a valid XML docuement
-     *     and which can be validated successfully against an XML schema
-     *     such as MODS.
-     */
-    private function oneParentWrapperElement($xmlString)
-    {
-
-        $xml = new \DomDocument();
-        $xml->loadXML($xmlString);
-
-        // Unique names of element nodes that are children of MODS root element.
-        // array returned is is the list of unique child element signatures 
-        // (that is, keeps track of attributes)
-        $uniqueChildNodeSignatureArray = $this->getChildNodesFromModsXMLString($xmlString);
-
-        // Determine which child elements of MODS root element are wrapper elements:
-        //  1) They have child elements of type XML_ELEMENT_NODE (Value: 1)
-        $wrapperElementArray =
-          $this->determineRepeatedWrapperChildElements($xml, $uniqueChildNodeSignatureArray);
-
-        // remove repeated wrapper nodes.        
-        foreach ($wrapperElementArray as $wrapperElement) {
-            $deleteThisNode = $wrapperElement;
-            if (isset($deleteThisNode->parentNode)) {
-                $parentNode = $deleteThisNode->parentNode;
-                $parentNode->removeChild($deleteThisNode);
-                $xml->saveXML($parentNode);
-            }
-        }
-        
-        // consolidate nodes with one wrapper
-        $consolidatedRepeatedWrapperElements =
-          $this->consolidateWrapperElements($wrapperElementArray);
-
-        // Add nodes back into $xml document.
-        $modsElement = $xml->getElementsByTagName('mods')->item(0);
-        foreach ($consolidatedRepeatedWrapperElements as $key => $valueArray) {
-            // $elementSignature array(elementName, array(attributeName=>attributeKey))
-            $elementSignature = $this->elementSignatureFromString($key);
-            $elementName = $elementSignature[0];
-            $elementAttributes = $elementSignature[1];
-
-            //$wrapperElement = $xml->createElement($key);
-            $wrapperElement = $xml->createElementNS('http://www.loc.gov/mods/v3', $elementName);
-            if(!empty($elementAttributes)){
-                // add attributes and values
-                foreach($elementAttributes as $key => $value) {
-                    $wrapperElement->setAttribute($key, $value);
-                }
-
-            }
-
-            foreach ($valueArray as $nodes) {
-                foreach ($nodes as $node) {
-                    $wrapperElement->appendChild($node);
-                }
-            }
-            $modsElement->appendChild($wrapperElement);
-            
-        }
-
-        $xmlString = $xml->saveXML();
-        return $xmlString;
-
-    }
-
-    /**
-     * Turn elementSignatureString into element name and attributes (with values)
-     * @param string $elementSignatureString example elementName?attribute0=value0|attribute1=value1|attribute2=value2
-     * @return array [elementNmae, array(attribute0=>value0, attribute1=value1, attribute2=value2, )]
-     */
-    private function elementSignatureFromString($elementSignatureString){
-
-            $elementNameAttributesArray = explode('?', $elementSignatureString);
-
-            $elementName = $elementNameAttributesArray[0];
-            
-            $elementAttributeKeyValueArray = array();
-            if(count($elementNameAttributesArray) > 1){
-                // element has attributes.
-                $elementAttributesArray = explode('|', $elementNameAttributesArray[1]);
-                // remove empty, false, or null values from the array.
-                $elementAttributesArray = array_filter($elementAttributesArray);
-                foreach($elementAttributesArray as $attributeValue){
-                    $attributeValuePair = explode('=', $attributeValue);
-                    $attributeName = $attributeValuePair[0];
-                    $attributeValue = $attributeValuePair[1];
-                    $elementAttributeKeyValueArray[$attributeName] = $attributeValue;
-
-                }
-            }
-             
-            return array($elementName, $elementAttributeKeyValueArray);
-    
-    }
-
-    /**
      * Applies metadatamanipulators listed in the config to provided XML snippet.
-     * @param string $xmlSnippet 
+     * @param string $xmlSnippet
      *     An XML snippet that can be turned into a valid XML document.
      * @param string $record_key
      *     The item's record key value.

--- a/src/metadataparsers/mods/Mods.php
+++ b/src/metadataparsers/mods/Mods.php
@@ -33,18 +33,25 @@ abstract class Mods extends MetadataParser
     }
 
     /**
-     *  Create MODS XML
-     *  @param array $colletionMappyingArray collection mappings
-     *  @param array $objectInfo array of info about the object that the MODS XML will be created for
+     *  Create MODS XML.
+     *
+     *  @param array $colletionMappyingArray
+     *    Collection mappings
+     *  @param array $objectInfo
+     *    Array of info about the object that the MODS XML will be created for
      */
     abstract public function createModsXML($collectionMappingArray, $objectInfo);
 
+    /**
+     *  Writes out the serialized MODS XML file.
+     *
+     *  @param string $modsxml
+     *     A MODS XML string.
+     *  @param string $outputPath
+     *     Destination path for the output file.
+     */
     public function outputModsXML($modsxml, $outputPath = '')
     {
-        /**
-         * $modsxml - MODS xml string - required.
-         * $outputPath - output path for writing to a file.
-         */
         if ($outputPath !='') {
             $filecreationStatus = file_put_contents($outputPath .'/MODS.xml', $modsxml);
             if ($filecreationStatus === false) {
@@ -71,7 +78,6 @@ abstract class Mods extends MetadataParser
         $childNodesElementSignatureStringArray = array();
         foreach ($xml->documentElement->childNodes as $node) {
             $elementName = $node->nodeName;
-
             $elementAttributesMap = array();
             $attributesNodeMap = $node->attributes;
             $len = $attributesNodeMap->length;
@@ -82,12 +88,10 @@ abstract class Mods extends MetadataParser
                 $elementAttributesMap[$attributeName] = $attributeValue;
             }
             $elementSignature = array($elementName, $elementAttributesMap);
-
             $childNodesElementSignatureArray[] = $this->signatureToString($elementSignature);
         }
 
         $returnArray = array_unique($childNodesElementSignatureArray);
-
         return $returnArray;
     }
 
@@ -95,20 +99,22 @@ abstract class Mods extends MetadataParser
      * Determine which child elements of MODS root element are wrapper elements:
      *  1) They have child elements of type XML_ELEMENT_NODE (Value: 1)
      *
-     * @param $xml object MODS XML object
+     * @param $xml object
+     *   MODS XML object
      *
-     * @param $uniqueChildNodeSignatureArray an array that lists the unique element
-     * signatures of children of the root MOD element.
+     * @param $uniqueChildNodeSignatureArray
+     *   An array that lists the unique element
+     *   signatures of children of the root MOD element.
      *
-     * @return arrry of XML elemets that are wrapper elements (children of root element).
+     * @return array of XML elemets that are wrapper elements (children of root element).
      */
     public function determineRepeatedWrapperChildElements($xml, $uniqueChildNodeSignatureArray)
     {
         $wrapperDomNodes = array();
-        // Grab the elements
+        // Grab the elements.
         foreach ($uniqueChildNodeSignatureArray as $nodeSignatureString) {
 
-            // Turn node signature string into parts element name + element attributes
+            // Turn node signature string into parts element name + element attributes.
             $nodeSignature = $this->elementSignatureFromString($nodeSignatureString);
 
             $nodeName = $nodeSignature[0];
@@ -116,7 +122,6 @@ abstract class Mods extends MetadataParser
             //DOMNodeList
             $nodeListObj = $xml->getElementsByTagName($nodeName);
             if ($nodeListObj->length >= 2 && !in_array($nodeName, $this->repeatableWrapperElements)) {
-
                 // The element name appears more than once and
                 // is not set as an allowed repeatable wrapper element.
                 foreach ($nodeListObj as $node) {
@@ -138,9 +143,11 @@ abstract class Mods extends MetadataParser
      * If a (parent) wrapper element more than once, consolidate the child nodes
      * into only one parent wrapper element and return the consolidated elements.
      *
-     * @param array $wrapperElementArray An array of wrapper elements.
+     * @param array $wrapperElementArray
+     *   An array of wrapper elements.
      *
-     * @return array An array of consolidated wrapper elements of type XML_ELEMENT_NODE
+     * @return array
+     *   An array of consolidated wrapper elements of type XML_ELEMENT_NODE
      */
     public function consolidateWrapperElements($wrapperElementArray)
     {
@@ -167,7 +174,7 @@ abstract class Mods extends MetadataParser
                 $attributeValue = $attributeItem->value;
                 $elementAttributesMap[$attributeName] = $attributeValue;
             }
-            // dev - rather than just check element name, check element name
+            // Rather than just check element name, check element name
             // and element attributes.
             $elementSignature = array($elementName, $elementAttributesMap);
 
@@ -179,7 +186,6 @@ abstract class Mods extends MetadataParser
             } else {
                 // $elementSignature is not in the tracking array, add it.
                 array_push($elementSignatureTrackingArray, $elementSignature);
-
                 $keyFromSignature = $this->signatureToString($elementSignature);
                  // $elementName is not in the tracking array, add it.
                 $elementNameTrackingArray[$keyFromSignature] = array($wrapperElement->childNodes);
@@ -222,7 +228,6 @@ abstract class Mods extends MetadataParser
      */
     public function oneParentWrapperElement($xmlString)
     {
-
         $xml = new \DomDocument();
         $xml->loadXML($xmlString);
 
@@ -287,9 +292,9 @@ abstract class Mods extends MetadataParser
             $elementName = $elementNameAttributesArray[0];
             $elementAttributeKeyValueArray = array();
             if(count($elementNameAttributesArray) > 1){
-                // element has attributes.
+                // Element has attributes.
                 $elementAttributesArray = explode('|', $elementNameAttributesArray[1]);
-                // remove empty, false, or null values from the array.
+                // Remove empty, false, or null values from the array.
                 $elementAttributesArray = array_filter($elementAttributesArray);
                 foreach($elementAttributesArray as $attributeValue){
                     $attributeValuePair = explode('=', $attributeValue);

--- a/src/metadataparsers/mods/Mods.php
+++ b/src/metadataparsers/mods/Mods.php
@@ -54,4 +54,250 @@ abstract class Mods extends MetadataParser
             }
         }
     }
+
+    /**
+     *  Takes MODS XML string and returns an array the unique element
+     *  signature strings of the child elements.
+     *
+     *  @param string $xmlString An MODS XML string.
+     *
+     *  @return array of unique child node element signature strings.
+     */
+    public function getChildNodesFromModsXMLString($xmlString)
+    {
+        $xml = new \DomDocument();
+        $xml->loadXML($xmlString);
+
+        $childNodesElementSignatureStringArray = array();
+        foreach ($xml->documentElement->childNodes as $node) {
+            $elementName = $node->nodeName;
+
+            $elementAttributesMap = array();
+            $attributesNodeMap = $node->attributes;
+            $len = $attributesNodeMap->length;
+            for($i = 0 ; $i < $len; ++$i) {
+                $attributeItem = $attributesNodeMap->item($i);
+                $attributeName = $attributeItem->name;
+                $attributeValue = $attributeItem->value;
+                $elementAttributesMap[$attributeName] = $attributeValue;
+            }
+            $elementSignature = array($elementName, $elementAttributesMap);
+
+            $childNodesElementSignatureArray[] = $this->signatureToString($elementSignature);
+        }
+
+        $returnArray = array_unique($childNodesElementSignatureArray);
+
+        return $returnArray;
+    }
+
+    /**
+     * Determine which child elements of MODS root element are wrapper elements:
+     *  1) They have child elements of type XML_ELEMENT_NODE (Value: 1)
+     *
+     * @param $xml object MODS XML object
+     *
+     * @param $uniqueChildNodeSignatureArray an array that lists the unique element
+     * signatures of children of the root MOD element.
+     *
+     * @return arrry of XML elemets that are wrapper elements (children of root element).
+     */
+    public function determineRepeatedWrapperChildElements($xml, $uniqueChildNodeSignatureArray)
+    {
+        $wrapperDomNodes = array();
+        // Grab the elements
+        foreach ($uniqueChildNodeSignatureArray as $nodeSignatureString) {
+
+            // Turn node signature string into parts element name + element attributes
+            $nodeSignature = $this->elementSignatureFromString($nodeSignatureString);
+
+            $nodeName = $nodeSignature[0];
+            $nodeAttributes = $nodeSignature[1];
+            //DOMNodeList
+            $nodeListObj = $xml->getElementsByTagName($nodeName);
+            if ($nodeListObj->length >= 2 && !in_array($nodeName, $this->repeatableWrapperElements)) {
+
+                // The element name appears more than once and
+                // is not set as an allowed repeatable wrapper element.
+                foreach ($nodeListObj as $node) {
+                    if ($node->hasChildNodes() /*&& !$node->hasAttributes()*/) {
+                        foreach ($node->childNodes as $childNode) {
+                            if ($childNode->nodeType == XML_ELEMENT_NODE) {
+                                $wrapperDomNodes[] = $node;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $wrapperDomNodes;
+    }
+
+    /**
+     * If a (parent) wrapper element more than once, consolidate the child nodes
+     * into only one parent wrapper element and return the consolidated elements.
+     *
+     * @param array $wrapperElementArray An array of wrapper elements.
+     *
+     * @return array An array of consolidated wrapper elements of type XML_ELEMENT_NODE
+     */
+    public function consolidateWrapperElements($wrapperElementArray)
+    {
+        $consolidatedWrapperElementsArray = array();
+        $elementNameTrackingArray = array();
+        $elementSignatureTrackingArray = array();
+        foreach ($wrapperElementArray as $wrapperElement) {
+            $name = $wrapperElement->nodeName;
+            $attributesNodeMap = $wrapperElement->attributes;
+            $length = $attributesNodeMap->length;
+            for($i=0; $i < $length; ++$i){
+               $attributeItem = $attributesNodeMap->item($i);
+               $attributeName = $attributeItem->name;
+               $attributeValue = $attributeItem->value;
+            }
+
+            $elementName = $wrapperElement->nodeName;
+            $elementAttributesMap = array();
+            $attributesNodeMap = $wrapperElement->attributes;
+            $len = $attributesNodeMap->length;
+            for($i = 0 ; $i < $len; ++$i) {
+                $attributeItem = $attributesNodeMap->item($i);
+                $attributeName = $attributeItem->name;
+                $attributeValue = $attributeItem->value;
+                $elementAttributesMap[$attributeName] = $attributeValue;
+            }
+            // dev - rather than just check element name, check element name
+            // and element attributes.
+            $elementSignature = array($elementName, $elementAttributesMap);
+
+            if (in_array($elementSignature, $elementSignatureTrackingArray)) {
+                // $elementName is already in the tracking array
+                // push the element's childnodes to the end of the array.
+                $keyFromSignature = $this->signatureToString($elementSignature);
+                array_push($elementNameTrackingArray[$keyFromSignature], $wrapperElement->childNodes);
+            } else {
+                // $elementSignature is not in the tracking array, add it.
+                array_push($elementSignatureTrackingArray, $elementSignature);
+
+                $keyFromSignature = $this->signatureToString($elementSignature);
+                 // $elementName is not in the tracking array, add it.
+                $elementNameTrackingArray[$keyFromSignature] = array($wrapperElement->childNodes);
+            }
+        }
+
+        return $elementNameTrackingArray;
+    }
+
+
+    /**
+     * Turns an signature to a string for use
+     */
+    public function signatureToString($elementSignature)
+    {
+        $signatureString = $elementSignature[0];
+        $attributesKeyValuesArray = $elementSignature[1];
+
+        if(count($attributesKeyValuesArray) > 0){
+            $signatureString .=  "?";
+            foreach($attributesKeyValuesArray as $key => $value) {
+               $signatureString .= $key . "=" . $value . "|";
+            }
+        }
+
+        return $signatureString;
+    }
+
+    /**
+     * Checks an XML string for common parent wrapper elements
+     * and uses only one as appropriate.
+     *
+     * @param string $xmlString
+     *     An XML snippet that can be turned into a valid XML document.
+     *
+     * @return string
+     *     An XML snippet that can be turned into a valid XML docuement
+     *     and which can be validated successfully against an XML schema
+     *     such as MODS.
+     */
+    public function oneParentWrapperElement($xmlString)
+    {
+
+        $xml = new \DomDocument();
+        $xml->loadXML($xmlString);
+
+        // Unique names of element nodes that are children of MODS root element.
+        // array returned is is the list of unique child element signatures
+        // (that is, keeps track of attributes)
+        $uniqueChildNodeSignatureArray = $this->getChildNodesFromModsXMLString($xmlString);
+
+        // Determine which child elements of MODS root element are wrapper elements:
+        //  1) They have child elements of type XML_ELEMENT_NODE (Value: 1)
+        $wrapperElementArray =
+          $this->determineRepeatedWrapperChildElements($xml, $uniqueChildNodeSignatureArray);
+
+        // Remove repeated wrapper nodes.
+        foreach ($wrapperElementArray as $wrapperElement) {
+            $deleteThisNode = $wrapperElement;
+            if (isset($deleteThisNode->parentNode)) {
+                $parentNode = $deleteThisNode->parentNode;
+                $parentNode->removeChild($deleteThisNode);
+                $xml->saveXML($parentNode);
+            }
+        }
+
+        // Consolidate nodes with one wrapper.
+        $consolidatedRepeatedWrapperElements =
+          $this->consolidateWrapperElements($wrapperElementArray);
+
+        // Add nodes back into $xml document.
+        $modsElement = $xml->getElementsByTagName('mods')->item(0);
+        foreach ($consolidatedRepeatedWrapperElements as $key => $valueArray) {
+            $elementSignature = $this->elementSignatureFromString($key);
+            $elementName = $elementSignature[0];
+            $elementAttributes = $elementSignature[1];
+
+            $wrapperElement = $xml->createElementNS('http://www.loc.gov/mods/v3', $elementName);
+            if (!empty($elementAttributes)){
+                // Add attributes and values.
+                foreach($elementAttributes as $key => $value) {
+                    $wrapperElement->setAttribute($key, $value);
+                }
+            }
+
+            foreach ($valueArray as $nodes) {
+                foreach ($nodes as $node) {
+                    $wrapperElement->appendChild($node);
+                }
+            }
+            $modsElement->appendChild($wrapperElement);
+        }
+
+        $xmlString = $xml->saveXML();
+        return $xmlString;
+    }
+
+    /**
+     * Turn elementSignatureString into element name and attributes (with values)
+     * @param string $elementSignatureString example elementName?attribute0=value0|attribute1=value1|attribute2=value2
+     * @return array [elementNmae, array(attribute0=>value0, attribute1=value1, attribute2=value2, )]
+     */
+    public function elementSignatureFromString($elementSignatureString){
+            $elementNameAttributesArray = explode('?', $elementSignatureString);
+            $elementName = $elementNameAttributesArray[0];
+            $elementAttributeKeyValueArray = array();
+            if(count($elementNameAttributesArray) > 1){
+                // element has attributes.
+                $elementAttributesArray = explode('|', $elementNameAttributesArray[1]);
+                // remove empty, false, or null values from the array.
+                $elementAttributesArray = array_filter($elementAttributesArray);
+                foreach($elementAttributesArray as $attributeValue){
+                    $attributeValuePair = explode('=', $attributeValue);
+                    $attributeName = $attributeValuePair[0];
+                    $attributeValue = $attributeValuePair[1];
+                    $elementAttributeKeyValueArray[$attributeName] = $attributeValue;
+                }
+            }
+            return array($elementName, $elementAttributeKeyValueArray);
+    }
 }


### PR DESCRIPTION
**Github issue**: (#40)

Related issue: #365, #25.

# What does this Pull Request do?

* Moves functions shared by the CdmToMods and CsvToMods metadata parsers into the parent MODS metadata parser class
* Some general cleanup of the resulting code

# What's new?

The CdmToMods and CsvToMods metadata parser classes are a lot smaller, and the MODS parent class is a lot bigger. All three files are a bit cleaner.

# How should this be tested?

The changes in this PR should be invisible, with no side effects. Therefore, the changes to the CsvToMods metadata parser are testable:

1. Check out the master branch and run the PHPUnit tests: `phpunit --exclude-group inputvalidators --bootstrap vendor/autoload.php tests`. You should get 46 tests and 66 assertions.
1. Check out the issue-40 branch and rerun the tests. You should get the same results.

Since there are no PHPUnit tests for the CdmToMods metadata parser, we will need to perform a smoke test. Configuration files for this are available on request. You may want to run MIK using the Cdm .ini file in master, rename the output directory, and then rerun it again in the issue-40 branch using the same .ini. The MODS files resulting from both runs should be identical except for timestamps.

# Interested parties

@MarcusBarnes 
