### PR TITLE
Work on #408 - add Filesystem fetcher

### DIFF
--- a/extras/scripts/postwritehooks/move_packages_by_extension.php
+++ b/extras/scripts/postwritehooks/move_packages_by_extension.php
@@ -19,7 +19,7 @@ $children_record_keys_string = trim($argv[2]);
 $config_path = trim($argv[3]);
 $config = parse_ini_file($config_path, true);
 
-// Define vvarious file paths.
+// Define various file paths.
 $mik_output_dir = $config['WRITER']['output_directory'];
 $file_path_with_no_ext = $mik_output_dir . DIRECTORY_SEPARATOR . $record_key;
 $files_with_name = glob($file_path_with_no_ext . ".*");

--- a/extras/scripts/postwritehooks/move_packages_by_extension.php
+++ b/extras/scripts/postwritehooks/move_packages_by_extension.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * MIK post-write hook script to move a single-file package
+ * (.xml and payload file) to a specific directory.
+ */
+
+// Directories must already exist. You will need to adjust these.
+$destinations = array(
+    'pdf' => '/tmp/filesystemfetcher/pdf',
+    'tif' => '/tmp/filesystemfetcher/largeimage',
+    'jp2' => '/tmp/filesystemfetcher/largeimage',
+    'jpg' => '/tmp/filesystemfetcher/basicimage',
+);
+
+// MIK post-write hook script setup stuff.
+$record_key = trim($argv[1]);
+$children_record_keys_string = trim($argv[2]);
+$config_path = trim($argv[3]);
+$config = parse_ini_file($config_path, true);
+
+// Define vvarious file paths.
+$mik_output_dir = $config['WRITER']['output_directory'];
+$file_path_with_no_ext = $mik_output_dir . DIRECTORY_SEPARATOR . $record_key;
+$files_with_name = glob($file_path_with_no_ext . ".*");
+$file_path = $files_with_name[0];
+$ext = pathinfo($file_path, PATHINFO_EXTENSION);
+
+// Move the payload and .xml file to the configured directory. Payload file first.
+rename($file_path, $destinations[$ext] . DIRECTORY_SEPARATOR . basename($file_path));
+// Then MODS XML file.
+$mods_dest_path = $destinations[$ext] . DIRECTORY_SEPARATOR . $record_key . '.xml';
+rename($mik_output_dir . DIRECTORY_SEPARATOR . $record_key . '.xml', $mods_dest_path);

--- a/extras/templates/filesystemfetcher.twig
+++ b/extras/templates/filesystemfetcher.twig
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <titleInfo>
+     <title>{{ title }}</title>
+  </titleInfo>
+  <identifier type="local" displayLabel="Local identifier">{{ title }}</identifier>
+</mods>

--- a/src/fetchers/Filesystem.php
+++ b/src/fetchers/Filesystem.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace mik\fetchers;
+
+class Filesystem extends Fetcher
+{
+    private $record_count;
+    
+    /**
+     * Create a new Filesystem Fetcher instance.
+     *
+     * @param array $settings configuration settings.
+     */
+    public function __construct($settings)
+    {
+        parent::__construct($settings);
+        $this->input_directory = rtrim($settings['FILE_GETTER']['input_directory'], DIRECTORY_SEPARATOR);
+
+        $this->record_key = 'ID';
+
+        if (isset($settings['MANIPULATORS']['fetchermanipulators'])) {
+            $this->fetchermanipulators = $settings['MANIPULATORS']['fetchermanipulators'];
+        } else {
+            $this->fetchermanipulators = null;
+        }
+
+        if (!$this->createTempDirectory()) {
+            $this->log->addError("Filesystem fetcher", array('Cannot create temp_directory'));
+        }
+    }
+
+    /**
+    * Return an array of records.
+    *
+    * @param $limit int
+    *   The number of records to get.
+    *
+    * @return array The records.
+    */
+    public function getRecords($limit = null)
+    {
+        $all_files = scandir($this->input_directory);
+        $entries = array_diff($all_files, array('.', '..'));
+
+        foreach ($entries as $entry) {
+            $record = new \stdClass;
+            $path_to_entry = $this->input_directory . DIRECTORY_SEPARATOR . $entry;
+            $record->ID = pathinfo($path_to_entry, PATHINFO_FILENAME);
+            $record->title = $entry;
+            $record->key = $record->{$this->record_key};
+            if (is_file($path_to_entry)) {
+                $records[] = $record;
+            }
+        }
+
+        // @todo: If there is a limit, slice the $records array.
+
+        if ($this->fetchermanipulators) {
+            $filtered_records = $this->applyFetchermanipulators($records);
+        } else {
+            $filtered_records = $records;
+        }
+
+        $this->record_count = count($filtered_records);
+        return $filtered_records;
+    }
+
+    /**
+     * Implements fetchers\Fetcher::getNumRecs.
+     *
+     * Returns the number of records under consideration.
+     *
+     * @return total number of records
+     *
+     * Note that extending classes must define this method.
+     */
+    public function getNumRecs()
+    {
+        static $num_recs;
+        if (!isset($num_recs) || !isset($this->record_count)) {
+            $num_recs = count($this->getRecords());
+        }
+        return $num_recs;
+    }
+
+    /**
+     * Implements fetchers\Fetcher::getItemInfo
+     *
+     * @param string $recordKey the unique record_key
+     *
+     * @return object The record.
+     */
+    public function getItemInfo($record_key)
+    {
+        $record = new \stdClass;
+        $record->key = $record_key;
+        // Getting the filename by globbing for it is brittle and hackish, but
+        // in the absence of an explicit value in input file, it'll have to do.
+        $file_path_with_no_ext = $this->input_directory . DIRECTORY_SEPARATOR . $record_key;
+        $files_with_name = glob($file_path_with_no_ext . ".*");
+        $record->title = basename($files_with_name[0]);
+        return $record;
+    }
+
+    /**
+     * Applies the fetchermanipulator listed in the config.
+     */
+    private function applyFetchermanipulators($records)
+    {
+        foreach ($this->fetchermanipulators as $manipulator) {
+            $manipulator_settings_array = explode('|', $manipulator);
+            $manipulator_class = '\\mik\\fetchermanipulators\\' . $manipulator_settings_array[0];
+            $fetchermanipulator = new $manipulator_class($this->all_settings,
+                $manipulator_settings_array);
+            $records = $fetchermanipulator->manipulate($records);
+        }
+        return $records;
+    }
+}

--- a/src/filegetters/CsvSingleFile.php
+++ b/src/filegetters/CsvSingleFile.php
@@ -18,7 +18,8 @@ class CsvSingleFile extends FileGetter
         $this->settings = $settings['FILE_GETTER'];
         $this->input_directory = $this->settings['input_directory'];
         $this->file_name_field = $this->settings['file_name_field'];
-        $this->fetcher = new \mik\fetchers\Csv($settings);
+        $fetcherClass = 'mik\\fetchers\\' . $settings['FETCHER']['class'];
+        $this->fetcher = new $fetcherClass($settings);
     }
 
     /**

--- a/src/inputvalidators/CsvSingleFile.php
+++ b/src/inputvalidators/CsvSingleFile.php
@@ -17,7 +17,8 @@ class CsvSingleFile extends MikInputValidator
     public function __construct($settings)
     {
         parent::__construct($settings);
-        $this->fetcher = new \mik\fetchers\Csv($settings);
+        $fetcherClass = 'mik\\fetchers\\' . $settings['FETCHER']['class'];
+        $this->fetcher = new $fetcherClass($settings);
     }
 
     public function validateAll()

--- a/tests/CsvInputValidatorsTest.php
+++ b/tests/CsvInputValidatorsTest.php
@@ -19,6 +19,7 @@ class CsvInputValidatorsTest extends \PHPUnit_Framework_TestCase
     {
         $settings = array(
             'FETCHER' => array(
+                'class' => 'Csv',
                 'use_cache' => false,
                 'input_file' => dirname(__FILE__) . '/assets/csv/inputvalidators/csvsinglefile/input.csv',
                 'temp_directory' => $this->path_to_temp_dir,
@@ -50,6 +51,7 @@ class CsvInputValidatorsTest extends \PHPUnit_Framework_TestCase
     {
         $settings = array(
             'FETCHER' => array(
+                'class' => 'Csv',
                 'use_cache' => false,
                 'input_file' => dirname(__FILE__) . '/assets/csv/inputvalidators/csvcompound/input.csv',
                 'temp_directory' => $this->path_to_temp_dir,
@@ -102,6 +104,7 @@ class CsvInputValidatorsTest extends \PHPUnit_Framework_TestCase
     {
         $settings = array(
             'FETCHER' => array(
+                'class' => 'Csv',
                 'use_cache' => false,
                 'input_file' => dirname(__FILE__) . '/assets/csv/inputvalidators/csvnewspapers/input.csv',
                 'temp_directory' => $this->path_to_temp_dir,
@@ -156,6 +159,7 @@ class CsvInputValidatorsTest extends \PHPUnit_Framework_TestCase
     {
         $settings = array(
             'FETCHER' => array(
+                'class' => 'Csv',
                 'use_cache' => false,
                 'input_file' => dirname(__FILE__) . '/assets/csv/inputvalidators/csvbooks/input.csv',
                 'temp_directory' => $this->path_to_temp_dir,

--- a/tests/CsvToJsonToolchainTest.php
+++ b/tests/CsvToJsonToolchainTest.php
@@ -22,6 +22,7 @@ class CsvToJsonToolchain extends \PHPUnit_Framework_TestCase
         // Define settings here, not in a configuration file.
         $settings = array(
             'FETCHER' => array(
+                'class' => 'Csv',
                 'input_file' => dirname(__FILE__) . '/assets/csv/sample_metadata.csv',
                 'temp_directory' => $this->path_to_temp_dir,
                 'record_key' => 'ID',
@@ -44,6 +45,7 @@ class CsvToJsonToolchain extends \PHPUnit_Framework_TestCase
     {
         $settings = array(
             'FETCHER' => array(
+                'class' => 'Csv',
                 'input_file' => dirname(__FILE__) . '/assets/csv/sample_metadata.csv',
                 'record_key' => 'ID',
                 'temp_directory' => $this->path_to_temp_dir,
@@ -66,6 +68,7 @@ class CsvToJsonToolchain extends \PHPUnit_Framework_TestCase
     {
         $settings = array(
             'FETCHER' => array(
+                'class' => 'Csv',
                 'input_file' => dirname(__FILE__) . '/assets/csv/sample_metadata.csv',
                 'record_key' => 'ID',
                 'temp_directory' => $this->path_to_temp_dir,
@@ -89,6 +92,7 @@ class CsvToJsonToolchain extends \PHPUnit_Framework_TestCase
     {
         $settings = array(
             'FETCHER' => array(
+                'class' => 'Csv',
                 'input_file' => dirname(__FILE__) . '/assets/csv/sample_metadata.csv',
                 'record_key' => 'ID',
                 'temp_directory' => $this->path_to_temp_dir,

--- a/tests/ExcelFetcherTest.php
+++ b/tests/ExcelFetcherTest.php
@@ -6,7 +6,7 @@ class ExcelFetcher extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        $this->path_to_temp_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_csv_fetcher_temp_dir";
+        $this->path_to_temp_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_excel_fetcher_temp_dir";
         $this->path_to_log = $this->path_to_temp_dir . DIRECTORY_SEPARATOR . "mik.log";
     }
 

--- a/tests/FilesystemFetcherTest.php
+++ b/tests/FilesystemFetcherTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace mik\fetchers;
+
+class FilesystemFetcher extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->path_to_temp_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_filesystem_fetcher_temp_dir";
+        $this->path_to_log = $this->path_to_temp_dir . DIRECTORY_SEPARATOR . "mik.log";
+    }
+
+    public function testGetRecords()
+    {
+        // Define settings here, not in a configuration file.
+        $settings = array(
+            'FETCHER' => array(
+                'temp_directory' => $this->path_to_temp_dir,
+            ),
+            'FILE_GETTER' => array(
+                 'input_directory' => dirname(__FILE__) . '/assets/filesystemfetcher',
+                 'validate_input' => false,
+                 'class' => 'CsvSingleFile',
+                 'file_name_field' => 'title',
+            ),
+            'LOGGING' => array(
+                'path_to_log' => $this->path_to_log,
+            ),
+        );
+        $filesystem = new Filesystem($settings);
+        $records = $filesystem->getRecords();
+        $this->assertCount(5, $records);
+    }
+    
+    public function testGetNumRecs()
+    {
+        $settings = array(
+            'FETCHER' => array(
+                'temp_directory' => $this->path_to_temp_dir,
+            ),
+            'FILE_GETTER' => array(
+                 'input_directory' => dirname(__FILE__) . '/assets/filesystemfetcher',
+                 'validate_input' => false,
+                 'class' => 'CsvSingleFile',
+                 'file_name_field' => 'title',
+            ),
+            'LOGGING' => array(
+                'path_to_log' => $this->path_to_log,
+            ),
+        );
+        $filesystem = new Filesystem($settings);
+        $num_records = $filesystem->getNumRecs();
+        $this->assertEquals(5, $num_records);
+    }
+
+    public function testGetItemInfo()
+    {
+        $settings = array(
+            'FETCHER' => array(
+                'temp_directory' => $this->path_to_temp_dir,
+            ),
+            'FILE_GETTER' => array(
+                 'input_directory' => dirname(__FILE__) . '/assets/filesystemfetcher',
+                 'validate_input' => false,
+                 'class' => 'CsvSingleFile',
+                 'file_name_field' => 'title',
+            ),
+            'LOGGING' => array(
+                'path_to_log' => $this->path_to_log,
+            ),						 
+        );
+        $filesystem = new Filesystem($settings);
+        $record = $filesystem->getItemInfo('testfile2');
+        $this->assertEquals('testfile2.tif', $record->title, "Record title is not testfile2.tif");
+    }
+
+    protected function tearDown()
+    {
+        $temp_files = glob($this->path_to_temp_dir . '/*');
+        foreach($temp_files as $temp_file) {
+            @unlink($temp_file);
+        }
+        @rmdir($this->path_to_temp_dir);
+    }
+
+}

--- a/tests/assets/filesystemfetcher/testfile1.tif
+++ b/tests/assets/filesystemfetcher/testfile1.tif
@@ -1,0 +1,1 @@
+Some TIFF data.

--- a/tests/assets/filesystemfetcher/testfile2.tif
+++ b/tests/assets/filesystemfetcher/testfile2.tif
@@ -1,0 +1,1 @@
+Some TIFF data.

--- a/tests/assets/filesystemfetcher/testfile3.tif
+++ b/tests/assets/filesystemfetcher/testfile3.tif
@@ -1,0 +1,1 @@
+Some TIFF data.

--- a/tests/assets/filesystemfetcher/testfile4.tif
+++ b/tests/assets/filesystemfetcher/testfile4.tif
@@ -1,0 +1,1 @@
+Some TIFF data.

--- a/tests/assets/filesystemfetcher/testfile5.tif
+++ b/tests/assets/filesystemfetcher/testfile5.tif
@@ -1,0 +1,1 @@
+Some TIFF data.


### PR DESCRIPTION
**Github issue**: #408

# What does this Pull Request do?

Adds a fetcher that uses a directory scan instead of an input file, in effect allowing you to use MIK to generate packages without any metadata. This fetcher is a drop-in replacement for the Csv fetcher in Csv toolchains.

# What's new?

* Added src/fetchers/Filesystem.php class file
* Updated some additional classes to avoid the hard-coded reference to the CSV fetcher.
* Added PHP unit tests for this new fetcher, plus an input directory to use in the tests (tests/assets/filesystemfetcher)
* Modified some other test files to explicitly use the Csv fetcher class.

# How should this be tested?

This change is testable. To test:

1. Check out the issue-408 branch.
1. Run the PHPUnit tests: `phpunit --exclude-group inputvalidators --bootstrap vendor/autoload.php tests`. You should get 52 tests, 72 assertions.

# Additional Notes

Draft cookbook entry is at https://github.com/MarcusBarnes/mik/wiki/Cookbook:-Using-the-Filesystem-fetcher (toolchain docs not updated yet).

Only works with single-file objects, but we can add compound and books and newspaper issues later.

I've tested this new fetcher on Linux and Windows and it works as intended.

# Interested parties

@MarcusBarnes 
