### PR TITLE
Work on #410 - allow input directories to be optional in Cdm toolchains

### DIFF
--- a/src/config/Config.php
+++ b/src/config/Config.php
@@ -267,15 +267,22 @@ class Config
         $filegetters = array('CdmNewspapers', 'CdmBooks', 'CdmSingleFile', 'CdmPhpDocuments');
         if (in_array($this->settings['FILE_GETTER']['class'], $filegetters)) {
             if (isset($this->settings['FILE_GETTER']['input_directories'])) {
+                $input_dirs = $this->settings['FILE_GETTER']['input_directories'];
+            }
+
+            if (is_array($input_dirs) && count($input_dirs)) {
                 $input_directories = $this->settings['FILE_GETTER']['input_directories'];
                 foreach ($input_directories as $input_directory) {
                     if (!file_exists(realpath($input_directory))) {
                         exit("Error: Can't find input directory $input_directory\n");
                     }
                 }
+                print "Input directory paths are OK.\n";
+            }
+            else {
+                print "No input directory paths are defined.\n";
             }
 
-            print "Input directory paths are OK.\n";
         }
 
         // For Csv toolchains, where a single input directory is allowed.

--- a/src/config/Config.php
+++ b/src/config/Config.php
@@ -264,20 +264,14 @@ class Config
      public function checkInputDirectories()
      {
         // For Cdm toolchains, where multiple input directories are allowed.
-        $filegetters = array('CdmNewspapers', 'CdmSingleFile', 'CdmPhpDocuments');
+        $filegetters = array('CdmNewspapers', 'CdmBooks', 'CdmSingleFile', 'CdmPhpDocuments');
         if (in_array($this->settings['FILE_GETTER']['class'], $filegetters)) {
-            if (!isset($this->settings['FILE_GETTER']['input_directories'])) {
-                print "No input directories are defined in the FILE_GETTER section.\n";
-                return;
-            }
-            if (strlen($this->settings['FILE_GETTER']['input_directories'][0]) == 0) {
-                print "No input directories are defined in the FILE_GETTER section.\n";
-                return;
-            }
-            $input_directories = $this->settings['FILE_GETTER']['input_directories'];
-            foreach ($input_directories as $input_directory) {
-                if (!file_exists(realpath($input_directory))) {
-                    exit("Error: Can't find input directory $input_directory\n");
+            if (isset($this->settings['FILE_GETTER']['input_directories'])) {
+                $input_directories = $this->settings['FILE_GETTER']['input_directories'];
+                foreach ($input_directories as $input_directory) {
+                    if (!file_exists(realpath($input_directory))) {
+                        exit("Error: Can't find input directory $input_directory\n");
+                    }
                 }
             }
 


### PR DESCRIPTION
**Github issue**: #410 

# What does this Pull Request do?

Fixes `--checkconfig` so it considers input directories optional in CONTENTdm toolchains.

# What's new?

`--checkconfig` no longer shows a notice when input directories are not configured: `“PHP Notice: Uninitialized string offset: 0 in /Users/barnes26/dev/mik/src/config/Config.php on line 273.”`

# How should this be tested?

We need to smoke test test two situations, one where there are no input directories configured and one where there are.

* Check out the issue-410 branch
* Create the input directories specified in the sample .ini file:

```
mkdir /tmp/issue410_1
mkdir /tmp/issue410_2
mkdir /tmp/issue410_3
```

* Using the sample .ini file, run MIK with its `--checkconfig` option:

`./mik -c issue-410.ini --cc all`

You should see the following output:

```
Commencing MIK.
Mapping snippets are OK
Paths are OK
CONTENTdm aliases are OK
Input directory paths are OK.
URLs are OK
```

* Uncomment the line `; input_directories =` and comment out the other instances of `input_directories[]`
* Rerun MIK: `./mik -c issue-410.ini --cc all`

You should see the following output:

```
Commencing MIK.
Mapping snippets are OK
Paths are OK
CONTENTdm aliases are OK
No input directory paths are defined.
URLs are OK
```

# Interested parties

@MarcusBarnes 