### PR TITLE
Not require SYSTEM

### DIFF
--- a/mik
+++ b/mik
@@ -79,17 +79,18 @@ if ($onWindows) {
 // it will create an E_WARNING, which will be turned into an excption
 // in the set_error_handler function halting the program.
 // Provide a default timezone if date.timezone is null in the the PHP INI.
-// Load [SYSTEM] stettings for user-defined default timeszone using config path
-$system_settings = parse_ini_file($configPath, true)['SYSTEM'];
-if (ini_get('date.timezone') == null || isset($system_settings['date_default_timezone'])) {
-    if(isset($system_settings['date_default_timezone'])){
-        $date_timezone = $system_settings['date_default_timezone'];
+// Load [SYSTEM] settings for user-defined default timezone using config path
+if (ini_get('date.timezone') == null || (
+        isset($settings['SYSTEM']) && isset($settings['SYSTEM']['date_default_timezone']))
+) {
+    if (isset($settings['SYSTEM']) && isset($settings['SYSTEM']['date_default_timezone'])) {
+        $date_timezone = $settings['SYSTEM']['date_default_timezone'];
         date_default_timezone_set($date_timezone);
     } else {
         // Use a default time-zone.
         date_default_timezone_set('America/Vancouver');
     }
-};
+}
 
 // Converts all errors into Exceptions.
 // Set here so that you can pass the configuration settings to the MIK Error Exception class.
@@ -317,13 +318,13 @@ foreach ($records as $record) {
 
 // Run any shutdown hooks.
 if (isset($settings['WRITER']['shutdownhooks'])) {
-  echo PHP_EOL; 
+  echo PHP_EOL;
   foreach ($settings['WRITER']['shutdownhooks'] as $hook) {
     $cmd = sprintf("%s %s", $hook, realpath($configPath));
     echo "Running shutdown hook # $hook" . PHP_EOL;
     exec($cmd);
   }
-  echo PHP_EOL; 
+  echo PHP_EOL;
 }
 
 


### PR DESCRIPTION
**Github issue**: #412 

# What does this Pull Request do?

Removes the requirement of a `SYSTEM` section of the `config.ini`

# What's new?

`mik` required you to have the `SYSTEM` section just in case your timezone was not set. But conceivably never checked it, it also parsed the settings file twice.

This uses the existing array of settings and only checks for SYSTEM if we need it.

# How should this be tested?

I'm going to suggest that if tests run before and after this PR with the same count you should be fine. However my PHPUnit is not letting me run existing tests under PHP 7

But you could try running `mik` without a `SYSTEM` section in your `config.ini` and you should (depending on your PHP installation) get the PHP timezone or 'America/Vancouver' 😄 

To help reviewers test your work:

* Indicate whether your work requires a smoke test or is covered by PHPUnit tests (see CONTRIBUTING.md for more information). 
* If your work is covered by PHPUnit tests, indicate how many successful tests and assertions the reviewer should see when they run your tests.
* If your work requires a smoke test, provide sample configuration files and data for reviewers.
* Be as detailed as possible.
* Good testing instructions and sample confiruation files/data help get your PR completed faster.

   Should be covered by existing tests, but again I haven't been able to run them. There is no new functionality added in here, just a different way of achieving the same thing.

# Additional Notes

Any additional information that you think would be helpful when reviewing this PR.

Example:

* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Could this change impact execution of existing code? no

# Interested parties
