### PR TITLE
Work on #428.

### DIFF
--- a/src/filegetters/CsvBooks.php
+++ b/src/filegetters/CsvBooks.php
@@ -26,10 +26,7 @@ class CsvBooks extends FileGetter
         $this->input_directory = $this->settings['input_directory'];
         $this->file_name_field = $this->settings['file_name_field'];
         $this->fetcher = new \mik\fetchers\Csv($settings);
-
-        // Interate over inputDirectories to create $potentialObjFiles array.
-        $potentialObjFiles = $this->getMasterFiles($this->input_directory, $this->allowed_file_extensions_for_OBJ);
-        $this->OBJFilePaths = $this->determineObjItems($potentialObjFiles);
+        $this->OBJFilePaths = $this->getMasterFiles($this->input_directory, $this->allowed_file_extensions_for_OBJ);
     }
 
     /**
@@ -46,12 +43,9 @@ class CsvBooks extends FileGetter
     {
         $page_paths = array();
         $book_input_path = $this->getBookSourcePath($record_key);
-        foreach ($this->OBJFilePaths as $paths) {
-            foreach ($paths as $path) {
-                // If there's a match, we expect it to start at position 0.
-                if (strpos($path, $book_input_path) === 0) {
-                    $page_paths[] = $path;
-                }
+        foreach ($this->OBJFilePaths as $path) {
+            if (strpos($path, $book_input_path) === 0) {
+                $page_paths[] = $path;
             }
         }
         return $page_paths;
@@ -62,7 +56,7 @@ class CsvBooks extends FileGetter
      *
      * @param string $inputDirectory
      *    The input directory as defined in the configuration.
-     * @param array $allowedFileTypes
+     * @param array  $allowedFileTypes
      *    The list of file types (e.g. extensions) to look for.
      *
      * @return array
@@ -92,77 +86,27 @@ class CsvBooks extends FileGetter
             $potentialObjFiles = array_merge($potentialObjFiles, $potentialFilesArray);
             $potentialObjFiles = array_unique($potentialObjFiles);
         }
-
         return $potentialObjFiles;
     }
 
     /**
-     * @todo: how does this relate to books?
-     *
-     * Filters out paths to files that do not have a yyyy-mm-dd date in their parent directories.
-     *
-     * @param array $arrayOfFilesToPreserve
-     *    The list of file types (e.g. extensions) to look for.
-     *
-     * @return array
-     *    An associative array with keys containing dates in yyyy-mm-dd
-     *    format and values containing paths to files with the key date.
-     */
-    private function determineObjItems($arrayOfFilesToPreserve)
-    {
-        // This regex will look for a pattern like /yyyy-mm-dd/ in the path that
-        // represents the issue date for the newspaper. Assumes publication frequency
-        // of at most one issue daily.
-        // $regex_pattern = '%[/\\\\][0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][/\\\\]%';
-        $regex_pattern = '%.%';
-
-        $dateForIdentifierArray = array();
-        foreach ($arrayOfFilesToPreserve as $path) {
-            preg_match($regex_pattern, $path, $matches);
-            if ($matches) {
-                array_push($dateForIdentifierArray, $matches[0]);
-            }
-        }
-        $dateForIdentifierArray = array_unique($dateForIdentifierArray);
-
-        $dictOfItems = array();
-        foreach ($dateForIdentifierArray as $dateIdentifier) {
-            $tempItemList = array();
-            foreach ($arrayOfFilesToPreserve as $filepath) {
-                if (stristr($filepath, $dateIdentifier)) {
-                    array_push($tempItemList, $filepath);
-                }
-            }
-
-            if (count($tempItemList) > 0) {
-                $dictOfItems[$dateIdentifier] = $tempItemList;
-            }
-        }
-        return $dictOfItems;
-    }
-
-    /**
-     * Return a list of absolute filepaths to the pages of a book.
+     * Return the absolute filepath to the pages of a book.
      *
      * @param $record_key
      *
      * @return string
-     *    The absolute paths to the issue's page files.
+     *    The absolute path to the book's page files.
      */
     public function getBookSourcePath($record_key)
     {
-        // Get the path to the issue.
         $item_info = $this->fetcher->getItemInfo($record_key);
         $book_directory = $item_info->{$this->file_name_field};
         $escaped_book_directory = preg_replace('/\-/', '\-', $book_directory);
-        $directory_regex = '#' . DIRECTORY_SEPARATOR . $escaped_book_directory . DIRECTORY_SEPARATOR . '#';
-        foreach ($this->OBJFilePaths as $paths) {
-            foreach ($paths as $path) {
-                if (preg_match($directory_regex, $path)) {
-                    return pathinfo($path, PATHINFO_DIRNAME);
-                }
+        $directory_regex = preg_quote('#' . DIRECTORY_SEPARATOR . $escaped_book_directory . DIRECTORY_SEPARATOR . '#');
+        foreach ($this->OBJFilePaths as $path) {
+            if (preg_match($directory_regex, $path)) {
+                return pathinfo($path, PATHINFO_DIRNAME);
             }
         }
     }
-
 }


### PR DESCRIPTION
**Github issue**: (#428)

# What does this Pull Request do?

Fixes a problem with the CSV Books filegetter on Windows, and cleans up the code in the CSV Filegetter class substantially.

# What's new?

The regex at https://github.com/MarcusBarnes/mik/blob/master/src/filegetters/CsvBooks.php#L158 fails on Windows, where `DIRECTORY_SEPARATOR` is `\`, which escapes the succeeding character. This PR wraps the regex in `preg_quote()` to prevent this from happening.

Also, this PR refactors/simplifies the filegetter so we can remove the function `determineObjItems()`.

# How should this be tested?

This work is testable. Running `phpunit` in master and issue-428 branches should yield the same results (52 tests, 72 assertions).

You will need a Windows environment to run a smoke test, but in the absence of one, I can attest that the changed code works, on Windows at any rate, because I used MIK yesterday with these changes in place to process this 1100-page book: http://digital.lib.sfu.ca/islandora/object/rarebooks:1/pages.

# Interested parties

@MarcusBarnes 
