### PR TITLE
add logic for DIRECTORY_SEPARATOR to account for "/" or "\" in reposi…

### DIFF
--- a/src/writers/Oaipmh.php
+++ b/src/writers/Oaipmh.php
@@ -133,6 +133,8 @@ class Oaipmh extends Writer
     public function normalizeFilename($string)
     {
         $string = urldecode($string);
+        $pattern = '#'.DIRECTORY_SEPARATOR.'#';
+        $string = preg_replace($pattern, '-', $string);
         $string = preg_replace('/:/', '_', $string);
         return $string;
     }


### PR DESCRIPTION
…tory unique identifier

# What does this Pull Request do?

We encountered a problem harvesting OAI, where someone's repository unique identifier had problematic characters IE: '/'

# What's new?

We added logic to the src/writers/Oaipmh.php  normalize_filename function, that would account for system directory separators. we chose to use hyphens to replace.

# How should this be tested? 

Set your repository unique identifier in islandora_oai config to http://example.com

Then try to harvest oai-pmh from there.


any sample oai-pmh sample config should work.


* Does this change require documentation to be updated? 
set_spec was a little hard to figure out. also the OAI example for harvesting from other islandoras, wasn't in the wiki TOC.

# Interested parties @mjordan 

Tag interested parties using @ mentions