### PR TITLE
Work on #436.

### DIFF
--- a/src/filegetters/CsvNewspapers.php
+++ b/src/filegetters/CsvNewspapers.php
@@ -147,8 +147,8 @@ class CsvNewspapers extends FileGetter
         // Get the path to the issue.
         $item_info = $this->fetcher->getItemInfo($record_key);
         $issue_directory = $item_info->{$this->file_name_field};
-        $escaped_issue_directory = preg_replace('/\-/', '\-', $issue_directory);
-        $directory_regex = '#' . DIRECTORY_SEPARATOR . $escaped_issue_directory . DIRECTORY_SEPARATOR . '#';
+        $directory_regex = '#' . DIRECTORY_SEPARATOR . $issue_directory . DIRECTORY_SEPARATOR . '#';
+        $directory_regex = preg_quote($directory_regex);
         foreach ($this->OBJFilePaths as $paths) {
             foreach ($paths as $path) {
                 if (preg_match($directory_regex, $path)) {


### PR DESCRIPTION
**Github issue**: (#436)

# What does this Pull Request do?

Escapes a regex pattern so that it doesn't fail on Windows.

# What's new?

As explained in the issue, adds the line `$directory_regex = preg_quote($directory_regex);` to the CsvNewspapers filegetter so the the DIRECTORY_SEPARATOR on Windows (`\`) is escaped properly.

# How should this be tested?

This change can only be tested thoroughly on Windows, but I used it yesterday to successfully generate a batch on Windows. On non-windows platforms, the fix should be invisible. To test this:

1. unzip the attached file, which contains some sample data and config files.
1. adjust values in the .ini to match your system.
1. in the master branch, run `./mik -c issue_436.ini`
1. change the name of the output directory so it is not overwritten in the next step
1. switch to the issue-436 branch and rerun `./mik -c issue_436.ini`
1. the output from the two branches should be identical (apart from timestamps in log files)

Results of PHP tests should also be the same across the master and issue-436 branches. In the mik directory, run:

`phpunit`

[issue_436.zip](https://github.com/MarcusBarnes/mik/files/1322268/issue_436.zip)

