### PR TITLE
Issue 439

### DIFF
--- a/src/filegetters/OaipmhIslandoraObj.php
+++ b/src/filegetters/OaipmhIslandoraObj.php
@@ -74,7 +74,7 @@ class OaipmhIslandoraObj extends FileGetter
         // endpoint is on the same host as the datastream files.
         $islandora_url_info = parse_url($this->oai_endpoint);
         if (isset($islandora_url_info['port'])) {
-            $port = $islandora_url_info['port'];
+            $port = ':' . $islandora_url_info['port'];
         } else {
             $port = '';
         }

--- a/src/metadataparsers/dc/OaiToDc.php
+++ b/src/metadataparsers/dc/OaiToDc.php
@@ -22,7 +22,7 @@ class OaiToDc extends Dc
     }
 
     /**
-     * Parse the DC XML out of the raw OAI record.
+     * Pass the OAI record and through the configured XSLT.
      *
      * @param string $objectInfo
      *   The raw OAI record XML.
@@ -30,7 +30,7 @@ class OaiToDc extends Dc
      * @return string
      *   The OAI DC XML.
      */
-    public function createDcXML($objectInfo)
+    public function createDcXML($MappingArray, $objectInfo)
     {
         $xml_doc = new \DOMDocument();
         $xml_doc->loadXML($objectInfo);
@@ -78,7 +78,7 @@ class OaiToDc extends Dc
     public function metadata($record_key)
     {
         $objectInfo = $this->fetcher->getItemInfo($record_key);
-        $metadata = $this->createDcXML($objectInfo);
+        $metadata = $this->createDcXML(array(), $objectInfo);
         return $metadata;
     }
 }

--- a/src/metadataparsers/dc/OaiToDc.php
+++ b/src/metadataparsers/dc/OaiToDc.php
@@ -23,12 +23,6 @@ class OaiToDc extends Dc
 
     /**
      * Pass the OAI record and through the configured XSLT.
-     *
-     * @param string $objectInfo
-     *   The raw OAI record XML.
-     *
-     * @return string
-     *   The OAI DC XML.
      */
     public function createDcXML($MappingArray, $objectInfo)
     {

--- a/src/metadataparsers/mods/OaiToMods.php
+++ b/src/metadataparsers/mods/OaiToMods.php
@@ -1,9 +1,9 @@
 <?php
-// src/metadataparsers/dc/OaiToDc.php
+// src/metadataparsers/dc/OaiToMods.php
 
-namespace mik\metadataparsers\dc;
+namespace mik\metadataparsers\mods;
 
-class OaiToDc extends Dc
+class OaiToMods extends Mods
 {
 
     /**
@@ -22,30 +22,32 @@ class OaiToDc extends Dc
     }
 
     /**
-     * Parse the DC XML out of the raw OAI record.
+     * Parse the MODS XML out of the raw OAI record.
      *
+     * @param array $array
+     *   Placeholder array.
      * @param string $objectInfo
      *   The raw OAI record XML.
      *
      * @return string
-     *   The OAI DC XML.
+     *   The MODS XML.
      */
-    public function createDcXML($objectInfo)
+    public function createModsXML($array, $objectInfo)
     {
         $xml_doc = new \DOMDocument();
         $xml_doc->loadXML($objectInfo);
         $xpath = new \DOMXPath($xml_doc);
         $xpath->registerNamespace("oai", "http://www.openarchives.org/OAI/2.0/");
-        $xpath->registerNamespace("oai_dc", "http://www.openarchives.org/OAI/2.0/oai_dc/");
+        $xpath->registerNamespace("mods", "http://www.loc.gov/mods/v3");
         $result = $xpath->query('//oai:metadata/*', $xml_doc);
-        $dc_xml_nodelist = $result->item(0);
-        $dc_xml = $xml_doc->saveXML($dc_xml_nodelist);
+        $mods_xml_nodelist = $result->item(0);
+        $mods_xml = $xml_doc->saveXML($mods_xml_nodelist);
 
         if (!is_null($this->metadatamanipulators)) {
-            $dc_xml = $this->applyMetadatamanipulators($dc_xml, $record_key);
+            $mods_xml = $this->applyMetadatamanipulators($mods_xml, $record_key);
         }
 
-        return $dc_xml;
+        return $mods_xml;
     }
 
     /**
@@ -78,7 +80,7 @@ class OaiToDc extends Dc
     public function metadata($record_key)
     {
         $objectInfo = $this->fetcher->getItemInfo($record_key);
-        $metadata = $this->createDcXML($objectInfo);
+        $metadata = $this->createModsXML(array(), $objectInfo);
         return $metadata;
     }
 }


### PR DESCRIPTION
**Github issue**: (#439)

# What does this Pull Request do?

Adds a MODS metadata parser for OAI-PMH toolchains.

# What's new?

Adds class `src/metadataparsers/mods/OaiToMods.php`. During development I found another issue which are not directly related to this new class but that I would like to include in this PR since it will affect the ability to test the new class:

* a bug in the OaipmhIslandoraObj.php filegetter that caused MIK to fail when the OAI endpoint contained an eplicit port number

# How should this be tested?

A smoketest is required since there are no PHPUnit tests for this change.

## Reproducing the problems

* Using the .ini file attached below, configure an OAI-PMH job that harvests from a collection on a Vagrant (e.g., host is http://localhost:8000).
* MIK will fail. Two specific things to look for in mik.log:
  * Your MIK log will contain HTTP "Name or service unknown" errors, since localhost8000 is not valid hostname. This failure happens when MIK attempts to download the OBJ.
  * The metadata logged in mik.log will be MODS, despite the .ini configuration setting `[METADATA_PARSER] class = dc\OaiToDc`

## Confirming the fix

* Check out the issue-439 branch.
* run `composer dump-autoload`
* Delete the MIK output and temp directories populated during replicating the problem.
* Rerun MIK using the same configuration file as above, after swapping the `[METADATA_PARSER]class` to use `mods\OaiToMods`.
* Your MIK log should be clean, and the XML files in the output directory should be MODS.


# Additional Notes

The wiki entries of the OAI-PMH toolchains will need to be updated to indicate how MODS can be harvested.

# Interested parties

@marcusbarnes. @bondjimbond used the OAI toolchain frequently and may want to smoketest.

[issue-439.ini.txt](https://github.com/MarcusBarnes/mik/files/1341232/issue-439.ini.txt)
