### PR TITLE
Issue 442 - checkconfig failure on null mappings

### DIFF
--- a/mik
+++ b/mik
@@ -35,6 +35,12 @@ $cmd->option('checkconfig')
         return in_array($cc_option, $cc_options);
     });
 
+$cmd->option('ignore_null_mappings')
+    ->aka('i')
+    ->describedAs('Ingore validating null mappings. If omitted, null mappings will be validated.')
+    ->boolean()
+    ->default(FALSE);
+
 $cmd->option('limit')
     ->aka('l')
     ->describedAs('Number of objects to process. If omitted, all objects will be processed.')
@@ -49,7 +55,7 @@ $settings = $mikConfig->settings;
 echo "Commencing MIK." . PHP_EOL;
 
 if ($cmd['checkconfig']) {
-    $mikConfig->validate($cmd['checkconfig']);
+    $mikConfig->validate($cmd);
 }
 
 if ($cmd['limit']) {

--- a/src/config/Config.php
+++ b/src/config/Config.php
@@ -133,14 +133,14 @@ class Config
 
         $reader = Reader::createFromPath($path);
         foreach ($reader as $index => $row) {
-            if ($cmd['ignore_null_mappings'] && preg_match('/^null/', $row[0]) && preg_match('/^null/', $row[1])) {
+            if ($cmd['ignore_null_mappings'] && preg_match('/^null/', $row[1])) {
                 continue;
-                if (count($row) > 1 && !preg_match('/^#/', $row[0])) {
-                    if (strlen($row[0])) {
-                        $doc = new \DOMDocument();
-                        if (!@$doc->loadXML($row[1])) {
-                            exit("Error: Mapping snippet $row[1] appears to be not well formed\n");
-                        }
+            }
+            if (count($row) > 1 && !preg_match('/^#/', $row[0])) {
+                if (strlen($row[0])) {
+                    $doc = new \DOMDocument();
+                    if (!@$doc->loadXML($row[1])) {
+                        exit("Error: Mapping snippet $row[1] appears to be not well formed\n");
                     }
                 }
             }


### PR DESCRIPTION
**Github issue**: (#442)

# What does this Pull Request do?

Provides a new command-line option, `--ignore_null_mappings`, which skips validating `null0,null0`-style mappings used by the InsertXmlFromTemplate metadata manipulator. Without this logic, those mappings trigger a false validation failure.

# What's new?

* addition to the `mik` script of a new command-line option, `--ignore_null_mappings`, which if present has a value of TRUE and if absent has a value of FALSE.
* addition to the `mik` script  of command-line help for this new option
* logic within src/config/Config.php to skip validating mappings whose right-hand value starts with `null` if the `--ignore_null_mappings` option is

# How should this be tested?

Changes in this PR do not have PHPUnit tests and must be smoke tested.

* To show that this change has no side effects, run mik in the `master` and `issue-442` branches with `--checkconfig snippets` or `--checkconfig all` on an .ini file that is known to pass config checks. Everything should work as it did before this PR.
* Using the .ini and mappings .csv file in the attached zip file,
  * run `./mik -c issue-442.ini --checkconfig snippets` or `./mik -c issue-442.ini --checkconfig all` and you should get an error indicating that "Mapping snippet null3 appears not to be well formed."
  * run `./mik -c issue-442.ini --checkconfig snippets --ignore_null_mappings` and you should get a message saying that "Mapping snippets are OK."

# Additional Notes

* https://github.com/MarcusBarnes/mik/wiki/Metadata-manipulator:-InsertXmlFromTemplate should be updated to say that unless `--ignore_null_mappings` is present, its mapping will trigger an error on `snippets` validation.
* https://github.com/MarcusBarnes/mik/wiki/Cookbook:-Check-your-MIK-configuration-values should also be updated to document this behavior.

# Interested parties

@bondjimbond

[issue-442.zip](https://github.com/MarcusBarnes/mik/files/1392748/issue-442.zip)
