### PR TITLE
Work on #452.

### DIFF
--- a/src/writers/CdmBooks.php
+++ b/src/writers/CdmBooks.php
@@ -213,7 +213,7 @@ class CdmBooks extends Writer
 
             // Get a JPEG to use as the Islandora preview image,
             //which should be 800 pixels high. The filename should be JPG.jpg.
-            $JPEG_expected = in_array('JPEG', $this->datastreams);
+            $JPEG_expected = in_array('JPG', $this->datastreams);
             if ($JPEG_expected xor $no_datastreams_setting_flag) {
                 $jpg_content = $this->cdmNewspapersFileGetter
                                 ->getPreviewJPGContent($page_pointer);

--- a/src/writers/CdmBooks.php
+++ b/src/writers/CdmBooks.php
@@ -217,7 +217,7 @@ class CdmBooks extends Writer
             if ($JPEG_expected xor $no_datastreams_setting_flag) {
                 $jpg_content = $this->cdmNewspapersFileGetter
                                 ->getPreviewJPGContent($page_pointer);
-                $jpg_output_file_path = $page_dir . DIRECTORY_SEPARATOR . 'JPEG.jpg';
+                $jpg_output_file_path = $page_dir . DIRECTORY_SEPARATOR . 'JPG.jpg';
                 file_put_contents($jpg_output_file_path, $jpg_content);
             }
 

--- a/src/writers/CdmNewspapers.php
+++ b/src/writers/CdmNewspapers.php
@@ -206,7 +206,7 @@ class CdmNewspapers extends Writer
             if ($JPEG_expected xor $no_datastreams_setting_flag) {
                 $jpg_content = $this->cdmNewspapersFileGetter
                                 ->getPreviewJPGContent($page_pointer);
-                $jpg_output_file_path = $page_dir . DIRECTORY_SEPARATOR . 'JPEG.jpg';
+                $jpg_output_file_path = $page_dir . DIRECTORY_SEPARATOR . 'JPG.jpg';
                 file_put_contents($jpg_output_file_path, $jpg_content);
             }
 

--- a/src/writers/CdmNewspapers.php
+++ b/src/writers/CdmNewspapers.php
@@ -202,7 +202,7 @@ class CdmNewspapers extends Writer
 
             // Get a JPEG to use as the Islandora preview image,
             //which should be 800 pixels high. The filename should be JPG.jpg.
-            $JPEG_expected = in_array('JPEG', $this->datastreams);
+            $JPEG_expected = in_array('JPG', $this->datastreams);
             if ($JPEG_expected xor $no_datastreams_setting_flag) {
                 $jpg_content = $this->cdmNewspapersFileGetter
                                 ->getPreviewJPGContent($page_pointer);


### PR DESCRIPTION
**Github issue**: #452

# What does this Pull Request do?

Fixes a bug that writes out incorrectly named JPEG datastreams created by the CONTENTdm newspapers and CONTENTdm books toolchains.

# What's new?

Changed the name of an output file in both of the affected writer classes.

# How should this be tested?

I've tested this against a CONTENTdm instance, with one book, using the following `[WRITER]` section in my .ini file:

```
[WRITER]
class = CdmBooks
alias = yyyyyyy
ws_url = "http://xxxxxxxxxxxxxxxx/dmwebservices/index.php?q="
output_directory = "/tmp/issue_452"
; Leave blank for Cdm single file objects (the MIK writer assigns the filename).
metadata_filename =
datastreams[] = MODS
datastreams[] = JPG
```

The JPEG datastream is now named properly (JPG instead of JPEG):

```
/tmp/issue_452
├── 3549
│   ├── 1
│   │   ├── JPG.jpg
│   │   ├── MODS.xml
│   │   └── OBJ.jpg
│   ├── 2
│   │   ├── JPG.jpg
│   │   ├── MODS.xml
│   │   └── OBJ.jpg
│   ├── 3
│   │   ├── JPG.jpg
│   │   ├── MODS.xml
│   │   └── OBJ.jpg
│   ├── 4
│   │   ├── JPG.jpg
│   │   ├── MODS.xml
│   │   └── OBJ.jpg
│   ├── 5
│   │   ├── JPG.jpg
│   │   ├── MODS.xml
│   │   └── OBJ.jpg
│   ├

[...]
```
I can't find any CONTENTdm to test with newspapers, but the CdmNewspapers writer works basically the same as the CdmBooks writer around the affected code.

# Other

Toolchain wiki pages https://github.com/MarcusBarnes/mik/wiki/Toolchain:-CONTENTdm-books and https://github.com/MarcusBarnes/mik/wiki/Toolchain:-CONTENTdm-newspapers will need to be updated to reflect the new DSID.


