### PR TITLE
Work on #451.

### DIFF
--- a/src/metadatamanipulators/AddUuidToTemplated.php
+++ b/src/metadatamanipulators/AddUuidToTemplated.php
@@ -1,0 +1,84 @@
+<?php
+// src/metadatamanipulators/SimpleReplaceTemplated.php
+
+namespace mik\metadatamanipulators;
+
+use \Monolog\Logger;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * AddUuidToTemplated - Adds a UUID to the output of the Templated metadata parser,
+ * similar to the AddUuidToMods.php metadata manipulator.
+ *
+ * Signature in .ini files is:
+ *
+ *   metadatamanipulators[] = "AddUuidToTemplated|/tmp/twigtemplates/mytemplate.xml"
+ *
+ * The template must contain the variable 'UUID', e.g. <identifier>{{ UUID }}</identifier>.
+ */
+class AddUuidToTemplated extends MetadataManipulator
+{
+    /**
+     * Create a new metadata manipulator instance.
+     */
+    public function __construct($settings, $paramsArray, $record_key)
+    {
+        parent::__construct($settings, $paramsArray, $record_key);
+        $this->record_key = $record_key;
+
+        // Set up logger.
+        $this->pathToLog = $this->settings['LOGGING']['path_to_manipulator_log'];
+        $this->log = new \Monolog\Logger('config');
+        $this->logStreamHandler = new \Monolog\Handler\StreamHandler(
+            $this->pathToLog,
+            Logger::INFO
+        );
+        $this->log->pushHandler($this->logStreamHandler);
+
+        if (count($paramsArray) == 1) {
+            $this->templatePath = $paramsArray[0];
+            $this->templateDirectory = pathinfo($paramsArray[0], PATHINFO_DIRNAME);
+            $this->templateFilename = pathinfo($paramsArray[0], PATHINFO_BASENAME);
+        } else {
+            $this->log->addInfo("AddUuidToTemplated", array('Wrong parameter count' => count($paramsArray)));
+        }
+    }
+
+    /**
+     * General manipulate wrapper method.
+     *
+     * @param string $input An XML file to be manipulated.
+     *
+     * @return string
+     *     Manipulated XML.
+     */
+    public function manipulate($input)
+    {
+        if (file_exists($this->templatePath)) {
+            $uuid4 = Uuid::uuid4();
+            $uuid_string = $uuid4->toString();
+
+            $loader = new \Twig_Loader_Filesystem($this->templateDirectory);
+            $twig = new \Twig_Environment($loader);
+            $xml_from_template = $twig->render($this->templateFilename, array('UUID' => $uuid_string));
+
+            // Convert $input into DOM, add child from template, reserialize DOM as XML and return it.
+            $dom = new \DOMDocument;
+            $dom->preserveWhiteSpace = true;
+            $dom->formatOutput = true;
+            $dom->loadXML($input);
+            $frag = $dom->createDocumentFragment();
+            $frag->appendXML($xml_from_template);
+            $dom->documentElement->appendChild($frag);
+            $this->log->addInfo("AddUuidToTemplated", array('Record key' => $this->record_key,
+                'Template applied' => $this->templatePath,
+                'UUID added' => $uuid_string
+            ));
+            return $dom->saveXML();
+        } else {
+            $this->log->addWarning("AddUuidToTemplated", array('Record key' => $this->record_key,
+                'Template not found' => $this->templatePath
+            ));
+        }
+    }
+}


### PR DESCRIPTION
**Github issue**: #451 

# What does this Pull Request do?

Adds a metadata manipulator that appends an element containing a UUID to metadata XML created by the Templated metadata parser.

# What's new?

A new metadata manipulator. It takes a Twit template like

```xml
<identifier type="uuid">{{ UUID }}</identifier>
```
and appends it to the output of the Templated metadata parser, like this:

```xml
<?xml version="1.0"?>
<mods xmlns="http://www.loc.gov/mods/v3" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleInfo>
     <title>Small boats in Havana Harbour on a sunney day</title>
  </titleInfo>
<identifier type="uuid">fb677095-2eb5-4acf-b310-ad8c3d0491cd</identifier>
</mods>
```

# How should this be tested?

This PR requires a smoke test; it is not testable.

1. Unzip the attached file, adjust the paths to in the .ini as required by your system
1. check out the issue-451 branch
1. run `composer dump-autoload`
1. run `./mik -c issue-451.ini`

Look at the XML files generated by MIK. They all should have a UUID element at the bottom.

[issue-451.zip](https://github.com/MarcusBarnes/mik/files/1739001/issue-451.zip)


# Additional Notes

* Does this change require documentation to be updated? 

Yes, it will require a wiki entry.

# Interested parties

@MarcusBarnes @bondjimbond 
