### PR TITLE
Issue 421

### DIFF
--- a/src/inputvalidators/CsvBooks.php
+++ b/src/inputvalidators/CsvBooks.php
@@ -31,11 +31,18 @@ class CsvBooks extends MikInputValidator
         // The separator is used here in a regex, so we escape it.
         if (isset($settings['WRITER']['page_sequence_separator'])) {
             $this->page_sequence_separator = $settings['WRITER']['page_sequence_separator'];
-        }
-        else {
+        } else {
             $this->page_sequence_separator = '-';
         }
         $this->page_sequence_separator = preg_quote($this->page_sequence_separator);
+
+        $this->ocr_extension = '.txt';
+        // Default is to not log the absence of page-level OCR files.
+        if (isset($settings['WRITER']['log_missing_ocr_files'])) {
+            $this->log_missing_ocr_files= $settings['WRITER']['log_missing_ocr_files'];
+        } else {
+            $this->log_missing_ocr_files = false;
+        }
     }
 
     /**
@@ -75,7 +82,7 @@ class CsvBooks extends MikInputValidator
      *   The package's record key.
      *
      * @param $package_path string
-     *   The the package's input directory name (not full path).
+     *   The package's input directory name (not full path).
      *
      * @return boolean
      *    True if all tests pass for the package, false if any tests failed.
@@ -136,6 +143,18 @@ class CsvBooks extends MikInputValidator
                 $cumulative_validation_results[] = false;
             }
 
+            if (!$this->checkOcrFiles($package_path, $pages)) {
+                $this->log->addError(
+                    "Input validation failed",
+                    array(
+                        'record ID' => $record_key,
+                        'issue directory' => $package_path,
+                        'error' => 'Book directory is missing one or more OCR files'
+                    )
+                );
+                $cumulative_validation_results[] = false;
+            }
+
             // Files in book directory must be named such that their last
             // filename segment is numeric.
             if (!$this->checkPageSequenceNumbers($pages)) {
@@ -181,18 +200,28 @@ class CsvBooks extends MikInputValidator
      */
     private function getPageFiles($dir)
     {
+        $page_files = array();
         $files = $this->readDir($dir);
         foreach ($files as &$file) {
             $file = basename($file);
+            foreach ($files as $file) {
+                $pathinfo = pathinfo($file);
+                $page_file = $pathinfo['basename'];
+                $ext = $pathinfo['extension'];
+                if (in_array($ext, array('tif','tiff', 'jp2'))) {
+                    $page_files[] = $page_file;
+                }
+            }
         }
-        return $files;
+        return $page_files;
     }
 
     /**
      * Validates the extensions of the pages in the book-level directory.
      *
      * @param $files array
-     *    A list of all the page file names.
+     *    A list of all the page file names.Files must have one of
+     *    following extensions: tif, tiff, jp2.
      *
      * @return boolean
      *    True if all files have an allowed file extension, false if not.
@@ -229,6 +258,35 @@ class CsvBooks extends MikInputValidator
                 if (!preg_match('/' . $this->page_sequence_separator . '\d+$/', $filename)) {
                     $valid = false;
                 }
+            }
+        }
+        return $valid;
+    }
+
+    /**
+     * Checks for the existence of page-level OCR files.
+     *
+     * @param $book_directory_path string
+     *    The absolute path to the book-level directory.
+     * @param $files array
+     *    A list of all the page file names in the directory.
+     *
+     * @return boolean
+     *    True if all image files have corresponding OCR files.
+     */
+    private function checkOcrFiles($book_directory_path, $files)
+    {
+        $valid = true;
+        if (!$this->log_missing_ocr_files) {
+            return $valid;
+        }
+        foreach ($files as $file) {
+            $pathinfo = pathinfo($file);
+            $filename = $pathinfo['filename'];
+            $path_to_ocr_file = realpath($book_directory_path) . DIRECTORY_SEPARATOR .
+                $filename . $this->ocr_extension;
+            if (!file_exists($path_to_ocr_file)) {
+                $valid = false;
             }
         }
         return $valid;

--- a/src/writers/CsvBooks.php
+++ b/src/writers/CsvBooks.php
@@ -214,11 +214,15 @@ class CsvBooks extends Writer
         $page_title = $titles->item(0)->nodeValue . ', page ' . $page_number;
         $page_title = htmlspecialchars($page_title, ENT_NOQUOTES|ENT_XML1);
 
+        $namespace = sprintf(
+            'xmlns="%s" xmlns:mods="%s" xmlns:xsi="%s" xmlns:xlink="%s"',
+            "http://www.loc.gov/mods/v3",
+            "http://www.loc.gov/mods/v3",
+            "http://www.w3.org/2001/XMLSchema-instance",
+            "http://www.w3.org/1999/xlink"
+        );
         $page_mods = <<<EOQ
-<mods xmlns="http://www.loc.gov/mods/v3"
-  xmlns:mods="http://www.loc.gov/mods/v3"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+<mods {$namespace}>
   <titleInfo>
     <title>{$page_title}</title>
   </titleInfo>


### PR DESCRIPTION
**Github issue**: (#421)

# What does this Pull Request do?

Adds the ability to include page-level OCR for book pages in the MIK CSV Book input. Use case here is that the OCR is generated outside Islandora. The CSV Newspapers toolchain already has this capability.

# What's new?

Changes to the CSV Books Writer class and CSV Books Input Validator class files that parallel those in the CSV newspaper classes. 

# How should this be tested?

This change does not include PHPUnit tests, so it needs to be smoke tested. To test:

1. Check out the issue-421 branch.
1. Unzip the file attached to this PR, which includes test configuration and data.
1. Adjust the paths in issue-421.ini to suit your system
1. Test the new functionality by running `php mik -c issue-421.ini`. The book ingest packages that are created by MIK should have OCR.txt files in all page-level directories.
1. Test that the input validator works by deleting the output and temp directories and changing `input_directory = "issue-421/files_no_text"` in your .ini file and rerunning MIK. Since the input directories do not contain OCR files, MIK will not produce any ingest packages and the input_validator log will indicate that there are missing OCR files.
1. Test that this PR works when there are not OCR files in the input directories, by deleting the output and temp directories and changing changing `log_missing_ocr_files` in your .ini file to FALSE and rerunning MIK. The output should be ingest packages that do not contain OCR.txt files. No problems should appear in any of the log files. `log_missing_ocr_files` has a default value of 'FALSE', so not including it in your .ini file will preserve the same behaviour that existed prior to this PR.

[issue-421.zip](https://github.com/MarcusBarnes/mik/files/1822840/issue-421.zip)

# Additional Notes

Any additional information that you think would be helpful when reviewing this PR.

Example:

* Does this change require documentation to be updated? 

Yes. The section in the CSV Newspapers toolchain wiki page "Including page-level OCR files" can be adapted for the CSV Books wiki page.

* Does this change add any new dependencies? 

No.

* Could this change impact execution of existing code?

Yes, but test data demonstrates that it doesn't.

# Interested parties

@bondjimbond @MarcusBarnes 
