### PR TITLE
Issue 421 - allow page-level OCR files in MIK input for CSV Books

### DIFF
--- a/src/inputvalidators/CsvBooks.php
+++ b/src/inputvalidators/CsvBooks.php
@@ -190,13 +190,13 @@ class CsvBooks extends MikInputValidator
     }
 
     /**
-     * Gets the filenames of the page files in the book-level directory.
+     * Gets the filenames of the files in the book-level directory.
      *
      * @param $dir string
      *    The full path to the book-level directory.
      *
      * @return array
-     *    A list of all the page file names.
+     *    A list of all the file names (not just page images).
      */
     private function getPageFiles($dir)
     {
@@ -207,10 +207,7 @@ class CsvBooks extends MikInputValidator
             foreach ($files as $file) {
                 $pathinfo = pathinfo($file);
                 $page_file = $pathinfo['basename'];
-                $ext = $pathinfo['extension'];
-                if (in_array($ext, array('tif','tiff', 'jp2'))) {
-                    $page_files[] = $page_file;
-                }
+                $page_files[] = $page_file;
             }
         }
         return $page_files;

--- a/src/inputvalidators/CsvBooks.php
+++ b/src/inputvalidators/CsvBooks.php
@@ -231,9 +231,11 @@ class CsvBooks extends MikInputValidator
             $ext = $pathinfo['extension'];
             if ($this->log_missing_ocr_files) {
                 $ocr_extension = ltrim($this->ocr_extension, '.');
-                $allowed_extensions = array_merge($this->fileGetter->allowed_file_extensions_for_OBJ, array($ocr_extension));
-            }
-            else {
+                $allowed_extensions = array_merge(
+                    $this->fileGetter->allowed_file_extensions_for_OBJ,
+                    array($ocr_extension)
+                );
+            } else {
                 $allowed_extensions = $this->fileGetter->allowed_file_extensions_for_OBJ;
             }
             if (!in_array($ext, $allowed_extensions)) {

--- a/src/inputvalidators/CsvBooks.php
+++ b/src/inputvalidators/CsvBooks.php
@@ -39,7 +39,7 @@ class CsvBooks extends MikInputValidator
         $this->ocr_extension = '.txt';
         // Default is to not log the absence of page-level OCR files.
         if (isset($settings['WRITER']['log_missing_ocr_files'])) {
-            $this->log_missing_ocr_files= $settings['WRITER']['log_missing_ocr_files'];
+            $this->log_missing_ocr_files = $settings['WRITER']['log_missing_ocr_files'];
         } else {
             $this->log_missing_ocr_files = false;
         }
@@ -229,7 +229,14 @@ class CsvBooks extends MikInputValidator
         foreach ($files as $file) {
             $pathinfo = pathinfo($file);
             $ext = $pathinfo['extension'];
-            if (!in_array($ext, $this->fileGetter->allowed_file_extensions_for_OBJ)) {
+            if ($this->log_missing_ocr_files) {
+                $ocr_extension = ltrim($this->ocr_extension, '.');
+                $allowed_extensions = array_merge($this->fileGetter->allowed_file_extensions_for_OBJ, array($ocr_extension));
+            }
+            else {
+                $allowed_extensions = $this->fileGetter->allowed_file_extensions_for_OBJ;
+            }
+            if (!in_array($ext, $allowed_extensions)) {
                 $valid = false;
             }
         }

--- a/src/writers/CsvBooks.php
+++ b/src/writers/CsvBooks.php
@@ -54,6 +54,14 @@ class CsvBooks extends Writer
             Logger::INFO
         );
         $this->log->pushHandler($this->logStreamHandler);
+
+        $this->ocr_extension = '.txt';
+        // Default is to not log the absence of page-level OCR files.
+        if (isset($settings['WRITER']['log_missing_ocr_files'])) {
+            $this->log_missing_ocr_files= $settings['WRITER']['log_missing_ocr_files'];
+        } else {
+            $this->log_missing_ocr_files = false;
+        }
     }
 
     /**
@@ -113,9 +121,8 @@ class CsvBooks extends Writer
         }
 
         // @todo: Add error handling on mkdir and copy.
-        // @todo: Write page level MODS.xml file, after testing ingest as is.
         foreach ($pages as $page_path) {
-            // Get the page number from the filename. It is the last segment.
+            // Get the sequence number from the last segment of the filename.
             $pathinfo = pathinfo($page_path);
             $filename_segments = explode($this->page_sequence_separator, $pathinfo['filename']);
 
@@ -126,14 +133,35 @@ class CsvBooks extends Writer
             $OBJ_expected = in_array('OBJ', $this->datastreams);
             if ($OBJ_expected xor $no_datastreams_setting_flag) {
                 $extension = $pathinfo['extension'];
-                $page_output_file_path = $page_level_output_dir . DIRECTORY_SEPARATOR .
+                $page_output_path = $page_level_output_dir . DIRECTORY_SEPARATOR .
                     'OBJ.' . $extension;
-                copy($page_path, $page_output_file_path);
+                copy($page_path, $page_output_path);
             }
 
             if ($MODS_expected xor $no_datastreams_setting_flag) {
                 if ($this->generate_page_modsxml) {
                     $this->writePageMetadataFile($metadata, $page_number, $page_level_output_dir);
+                }
+            }
+
+            // If the datastreams list is comprised of only 'MODS' we're generating metadata only.
+            if ($this->datastreams != array('MODS')) {
+                $OCR_expected = in_array('OCR', $this->datastreams);
+                if ($OCR_expected xor $no_datastreams_setting_flag) {
+                    $ocr_input_path = $pathinfo['dirname'] . DIRECTORY_SEPARATOR .
+                        $pathinfo['filename'] . $this->ocr_extension;
+                    $ocr_output_path = $page_level_output_dir . DIRECTORY_SEPARATOR .
+                        'OCR' . $this->ocr_extension;
+                    if (file_exists($ocr_input_path)) {
+                        copy($ocr_input_path, $ocr_output_path);
+                    } else {
+                        if ($this->log_missing_ocr_files) {
+                            $this->log->addWarning(
+                                "CSV Books warning",
+                                array('Page-level OCR file does not exist' => $ocr_input_path)
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/tests/inputvalidators/CsvInputValidatorsTest.php
+++ b/tests/inputvalidators/CsvInputValidatorsTest.php
@@ -217,6 +217,11 @@ class CsvInputValidatorsTest extends MikTestBase
             "CSV Books input validator did not detect unwanted files"
         );
         $this->assertContains(
+            'files/book3","error":"Some files in the book object directory have invalid extensions"',
+            $log_file_entries[3],
+            "CSV Books input validator did not find invalid page file extensions"
+        );
+        $this->assertContains(
             'files/book4","error":"Book object directory not found"',
             $log_file_entries[4],
             "CSV Books input validator did not detect empty book-level directory"


### PR DESCRIPTION
**Github issue**: (#421)

# What does this Pull Request do?

Adds the ability to include page-level OCR for book pages in the MIK CSV Book input. Use case here is that the OCR is generated outside Islandora. The CSV Newspapers toolchain already has this capability.

# What's new?

Changes to the CSV Books Writer class and CSV Books Input Validator class files that parallel those in the CSV newspaper classes. 

# How should this be tested?

This change does not include PHPUnit tests, so it needs to be smoke tested. However, PHPUnit tests continue to pass.

To smoke test:

1. Check out the issue-421 branch.
1. Unzip the file attached to this PR, which includes test configuration and data.
1. Adjust the paths in issue-421.ini to suit your system
1. Test the new functionality by running `php mik -c issue-421.ini`. The book ingest packages that are created by MIK should have OCR.txt files in all page-level directories.
1. Test that the input validator works by deleting the output and temp directories and changing the `input_directory` value to `input_directory = "issue-421/files_no_text"` in your .ini file and rerunning MIK. Since the input directories do not contain OCR files, MIK will not produce any ingest packages and the input_validator log will indicate that there are missing OCR files.
1. Test that this PR works when there are not OCR files in the input directories, by deleting the output and temp directories and changing changing `log_missing_ocr_files` in your .ini file to FALSE and rerunning MIK. The output should be ingest packages that do not contain OCR.txt files. No problems should appear in any of the log files. `log_missing_ocr_files` has a default value of 'FALSE', so not including it in your .ini file will preserve the same behaviour that existed prior to this PR.

[issue-421.zip](https://github.com/MarcusBarnes/mik/files/1822840/issue-421.zip)

# Additional Notes

Any additional information that you think would be helpful when reviewing this PR.

Example:

* Does this change require documentation to be updated? 

Yes. The section in the CSV Newspapers toolchain wiki page "Including page-level OCR files" can be adapted for the CSV Books wiki page.

* Does this change add any new dependencies? 

No.

* Could this change impact execution of existing code?

Yes, but test data demonstrates that it doesn't.

# Interested parties

@bondjimbond @MarcusBarnes 
