### PR TITLE
Initial work on #482.

### DIFF
--- a/src/metadataparsers/mods/CdmToMods.php
+++ b/src/metadataparsers/mods/CdmToMods.php
@@ -81,7 +81,7 @@ class CdmToMods extends Mods
     {
         // Do not convert nicknames to field labels.
         if ($this->use_nicknames) {
-          return $objectInfo;
+            return $objectInfo;
         }
 
         // Create array with field values of proper name as $keys rather than 'nick' keys

--- a/src/metadataparsers/mods/CdmToMods.php
+++ b/src/metadataparsers/mods/CdmToMods.php
@@ -66,6 +66,12 @@ class CdmToMods extends Mods
         } else {
             $this->metadatamanipulators = null;
         }
+
+        if (isset($this->settings['METADATA_PARSER']['use_nicknames'])) {
+            $this->use_nicknames= $this->settings['METADATA_PARSER']['use_nicknames'];
+        } else {
+            $this->use_nicknames = false;
+        }
     }
 
     /**
@@ -73,6 +79,11 @@ class CdmToMods extends Mods
      */
     private function createCONTENTdmFieldValuesArray($objectInfo)
     {
+        // Do not convert nicknames to field labels.
+        if ($this->use_nicknames) {
+          return $objectInfo;
+        }
+
         // Create array with field values of proper name as $keys rather than 'nick' keys
         $CONTENTdmFieldValuesArray = array();
         foreach ($objectInfo as $key => $value) {


### PR DESCRIPTION
**Github issue**: (#482)

* Other Relevant Links (Google Groups discussion, related pull requests, etc.)

# What does this Pull Request do?

Allows use of CONTENTdm metadata field "nicknames" in MIK mappings files and Twig-based metadata manipulators.

# What's new?

The nicknames are used internally in MIK, but we go out of our way to allow the use of the corresponding human-readable field labels in mappings files. This change effectively bypasses that conversion.

# How should this be tested?
@bondjimbond has already tested this thoroughly, but checking out this branch, then following the documentation in how to configure this option in https://github.com/MarcusBarnes/mik/wiki/Cookbook:-Using-CONTENTdm-field-nicknames-instead-of-labels should be sufficient.

# Additional Notes

* Does this change require documentation to be updated? 

https://github.com/MarcusBarnes/mik/wiki/Cookbook:-Using-CONTENTdm-field-nicknames-instead-of-labels created, and can be linked from the Cdm toolchain wiki pages and https://github.com/MarcusBarnes/mik/wiki/Metadata-manipulator:-InsertXmlFromTemplate.

* Does this change add any new dependencies? 

No.

* Could this change impact execution of existing code?

Yes.


