### PR TITLE
Creates root output directory if it does not exist.  Addresses issue #457.

### DIFF
--- a/src/writers/CsvBooks.php
+++ b/src/writers/CsvBooks.php
@@ -90,6 +90,9 @@ class CsvBooks extends Writer
             }
         }
 
+
+        //Create root output folder
+        $this->createOutputDirectory();
         // Create a book-level subdirectory in the output directory.
         $book_level_output_dir = $this->output_directory . DIRECTORY_SEPARATOR . $record_id;
         if (!file_exists($book_level_output_dir)) {


### PR DESCRIPTION
Creates the root output directory if it does not already exist for the CSVBook writer.  Addresses issue #457.

**Github issue**: https://github.com/MarcusBarnes/mik/issues/457

# What does this Pull Request do?

Adds a call to the createOutputDirectory method in the CSVBook writer so that the root output directory is created if the output directory currently doesn't exist, matching the behaviour of other CSV toolchain writer classes.

# How should this be tested?

This will require a smoke test, following the comments in the original issue https://github.com/MarcusBarnes/mik/issues/457.  Test both when the output_directory in the config  has been created before running MIK and also when it has not been created.

# Interested parties

@bondjimbond 
