### PR TITLE
Change include_migrated_from_uri to accept a URI and remove hard-coded SFU URI

### DIFF
--- a/src/metadataparsers/mods/CdmToMods.php
+++ b/src/metadataparsers/mods/CdmToMods.php
@@ -174,10 +174,10 @@ class CdmToMods extends Mods
         $includeMigratedFromUri = $this->includeMigratedFromUri;
         $itemId = $pointer;
         $collectionAlias = $this->alias;
-        if ($includeMigratedFromUri == true) {
+        if (!empty($includeMigratedFromUri)) {
             $CONTENTdmItemUrl = '<identifier type="uri" invalid="yes" ';
             $CONTENTdmItemUrl .= 'displayLabel="Migrated From">';
-            $CONTENTdmItemUrl .= 'http://content.lib.sfu.ca/cdm/ref/collection/';
+            $CONTENTdmItemUrl .= $includeMigratedFromUri;
             $CONTENTdmItemUrl .= $collectionAlias. '/id/'. $itemId .'</identifier>';
             $modsOpeningTag .= $CONTENTdmItemUrl;
         }


### PR DESCRIPTION
**Github issue**: #485 

# What does this Pull Request do?

Changes the behaviour of the include_migrated_from_uri parameter. Now the user should enter the base URI for their CDM collection. To not include a "migrated from" URI, leave it the value blank.

Possible issue: The line is required (MIK won't run properly without it). I don't know how to make it not required.

Documentation change needed: If there's no fix to make it not required, then some change to the documentation must reflect this. Plus of course we need to fix the documentation anyway to describe the new behaviour. 

# How should this be tested?

1. Run a CDM migration .ini file
2. Include the line `include_migrated_from_uri = TRUE`
3. Observe SFU base URL in your identifier tag
4. Check out this branch
5. Change line to `include_migrated_from_uri =`
6. Run MIK
7. Observe no "migrated from" identifier
8. Add a URI like `include_migrated_from_uri = http://deck.cs.athabascau.ca/cdm/ref/collection/`
9. Run MIK
10. Observe the new URI appearing in the metadata

# Additional Notes

It would be nice if someone could point out how to make MIK accept the variable not existing at all, instead of having to include an empty value in the .ini file.

# Interested parties

@MarcusBarnes @mjordan 
