### PR TITLE
Issue 495: Make extensions of page image files configurable in CSV Book and Newspaper toolchains

### DIFF
--- a/src/filegetters/CsvBooks.php
+++ b/src/filegetters/CsvBooks.php
@@ -9,10 +9,10 @@ class CsvBooks extends FileGetter
      * @var array allowed_file_extensions_for_OBJ - array of file extensions when searching
      * for master files (for OBJ datastreams).
      */
-    public $allowed_file_extensions_for_OBJ = array('tiff', 'tif', 'jp2');
+    // public $allowed_file_extensions_for_OBJ = array('tiff', 'tif', 'jp2');
 
     /**
-     * Create a new CSV Fetcher instance.
+     * Create a new CSV Books Filegetter instance.
      *
      * @param array $settings configuration settings.
      */
@@ -22,6 +22,11 @@ class CsvBooks extends FileGetter
         $this->input_directory = $this->settings['input_directory'];
         $this->file_name_field = $this->settings['file_name_field'];
         $this->fetcher = new \mik\fetchers\Csv($settings);
+        if (isset($this->settings['allowed_file_extensions_for_OBJ'])) {
+            $this->allowed_file_extensions_for_OBJ = $this->settings['allowed_file_extensions_for_OBJ'];
+        } else {
+            $this->allowed_file_extensions_for_OBJ = array('tiff', 'tif', 'jp2');
+        }
         $this->OBJFilePaths = $this->getMasterFiles($this->input_directory, $this->allowed_file_extensions_for_OBJ);
     }
 

--- a/src/filegetters/CsvBooks.php
+++ b/src/filegetters/CsvBooks.php
@@ -6,12 +6,6 @@ class CsvBooks extends FileGetter
 {
 
     /**
-     * @var array allowed_file_extensions_for_OBJ - array of file extensions when searching
-     * for master files (for OBJ datastreams).
-     */
-    // public $allowed_file_extensions_for_OBJ = array('tiff', 'tif', 'jp2');
-
-    /**
      * Create a new CSV Books Filegetter instance.
      *
      * @param array $settings configuration settings.

--- a/src/filegetters/CsvNewspapers.php
+++ b/src/filegetters/CsvNewspapers.php
@@ -21,7 +21,11 @@ class CsvNewspapers extends FileGetter
         $this->input_directory = $this->settings['input_directory'];
         $this->file_name_field = $this->settings['file_name_field'];
         $this->fetcher = new \mik\fetchers\Csv($settings);
-
+        if (isset($this->settings['allowed_file_extensions_for_OBJ'])) {
+            $this->allowed_file_extensions_for_OBJ = $this->settings['allowed_file_extensions_for_OBJ'];
+        } else {
+            $this->allowed_file_extensions_for_OBJ = array('tiff', 'tif', 'jp2');
+        }
         // Interate over inputDirectories to create $potentialObjFiles array.
         $potentialObjFiles = $this->getMasterFiles($this->input_directory, $this->allowed_file_extensions_for_OBJ);
         $this->OBJFilePaths = $this->determineObjItems($potentialObjFiles);

--- a/tests/filegetters/CsvBooksTest.php
+++ b/tests/filegetters/CsvBooksTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace mik\tests\filegetters;
+
+use mik\tests\MikTestBase;
+use mik\filegetters\CsvBooks;
+
+class CsvBooksFilegetterTest extends MikTestBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->path_to_temp_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_csv_book_filegetters_temp_dir";
+        parent::setUp();
+        $this->path_to_output_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_csv_book_filegetters_output_dir";
+        @mkdir($this->path_to_output_dir);
+        $this->path_to_log = $this->path_to_temp_dir . DIRECTORY_SEPARATOR . "mik.log";
+    }
+
+    public function testAllowedFileExtensions()
+    {
+        // Define settings here, not in a configuration file.
+        $settings = array(
+            'FETCHER' => array(
+                'class' => 'Csv',
+                'input_file' => $this->asset_base_dir . '/csv/books/metadata/books_metadata.csv',
+                'temp_directory' => $this->path_to_temp_dir,
+                'record_key' => 'Identifier',
+                'use_cache' => false
+            ),
+            'FILE_GETTER' => array(
+                'validate_input' => false,
+                'class' => 'CsvBooks',
+                'input_directory' => $this->asset_base_dir . '/csv/books/files_page_sequence_separator',
+                'temp_directory' => $this->path_to_temp_dir,
+                'file_name_field' => 'Directory',
+                'use_cache' => false,
+            ),
+            'LOGGING' => array(
+                'path_to_log' => $this->path_to_log,
+            ),
+        );
+        $file_getter = new CsvBooks($settings);
+        $this->assertEquals(
+            array('tiff', 'tif', 'jp2'),
+            $file_getter->allowed_file_extensions_for_OBJ,
+            "File extensions for OBJ not equal."
+        );
+
+        $settings['FILE_GETTER']['allowed_file_extensions_for_OBJ'] = array('tiff', 'tif');
+        $file_getter = new CsvBooks($settings);
+        $this->assertEquals(
+            array('tiff', 'tif'),
+            $file_getter->allowed_file_extensions_for_OBJ,
+            "File extensions for OBJ not equal."
+        );
+    }
+}

--- a/tests/filegetters/CsvNewspapersTest.php
+++ b/tests/filegetters/CsvNewspapersTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace mik\tests\filegetters;
+
+use mik\tests\MikTestBase;
+use mik\filegetters\CsvNewspapers;
+
+class CsvNewspapersFilegetterTest extends MikTestBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->path_to_temp_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_csv_newspapers_temp_dir";
+        parent::setUp();
+        $this->path_to_output_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "mik_csv_newspapers_output_dir";
+        @mkdir($this->path_to_output_dir);
+        $this->path_to_log = $this->path_to_temp_dir . DIRECTORY_SEPARATOR . "mik.log";
+    }
+
+    public function testAllowedFileExtensions()
+    {
+        // Define settings here, not in a configuration file.
+        $settings = array(
+            'FETCHER' => array(
+                'class' => 'Csv',
+                'input_file' => $this->asset_base_dir . '/csv/newspapers/metadata/newspapers_metadata.csv',
+                'temp_directory' => $this->path_to_temp_dir,
+                'record_key' => 'Identifier',
+                'use_cache' => false
+            ),
+            'FILE_GETTER' => array(
+                'validate_input' => false,
+                'class' => 'CsvNewspapers',
+                'input_directory' => $this->asset_base_dir . '/csv/newspapers/files/flat',
+                'temp_directory' => $this->path_to_temp_dir,
+                'file_name_field' => 'Directory',
+                'use_cache' => false,
+            ),
+            'LOGGING' => array(
+                'path_to_log' => $this->path_to_log,
+            ),
+        );
+        $file_getter = new CsvNewspapers($settings);
+        $this->assertEquals(
+            array('tiff', 'tif', 'jp2'),
+            $file_getter->allowed_file_extensions_for_OBJ,
+            "File extensions for OBJ not equal."
+        );
+
+        $settings['FILE_GETTER']['allowed_file_extensions_for_OBJ'] = array('jpg', 'tif');
+        $file_getter = new CsvNewspapers($settings);
+        $this->assertEquals(
+            array('jpg', 'tif'),
+            $file_getter->allowed_file_extensions_for_OBJ,
+            "File extensions for OBJ not equal."
+        );
+    }
+}


### PR DESCRIPTION
**Github issue**: #495

# What does this Pull Request do?

Makes extensions of page image files configurable in CSV Book and Newspaper toolchains.

# What's new?

In the CsvBooks.php and CsvNewspapers.php filegetter classes, replaced the hard-coded `$allowed_file_extensions_for_OBJ` property with a configuration option. The default values (if the option is not present in the .ini file) is the same as previously, to prevent backward breakage.

# How should this be tested?
This is a 'testable' change. I have included to new test classes, `tests/filegetters/CsvBooksTest.php` and `tests/filegetters/CsvNewspapersTest.php`. In the master branch, running `./vendor/bin/phpunit` results in:

```
OK, but incomplete, skipped, or risky tests!
Tests: 58, Assertions: 84, Skipped: 2.
```
In the issue-495 branch, running PHPUnit results in, showing two new tests and four new assertions:

```
OK, but incomplete, skipped, or risky tests!
Tests: 60, Assertions: 88, Skipped: 2.
```
In all new tests, I am testing for both the default value of `$allowed_file_extensions_for_OBJ` and a configured value. 

# Additional Notes

* Does this change require documentation to be updated?  Yes. The new configuration option should be documented on the two toolchain pages on the wiki. Here is an example of using the new option:

```
FILE_GETTER
allowed_file_extensions_for_OBJ[] = jpg
allowed_file_extensions_for_OBJ[] = tif
```

* Does this change add any new dependencies? No
* Could this change impact execution of existing code? Yes

# Interested parties

@MarcusBarnes @bondjimbond 
