### PR TITLE
Work on #498.

### DIFF
--- a/src/writers/CsvBooks.php
+++ b/src/writers/CsvBooks.php
@@ -130,6 +130,9 @@ class CsvBooks extends Writer
             $filename_segments = explode($this->page_sequence_separator, $pathinfo['filename']);
 
             $page_number = ltrim(end($filename_segments), '0');
+            if (strlen($page_number) === 0) {
+                $page_number = '0';
+            }
             $page_level_output_dir = $book_level_output_dir . DIRECTORY_SEPARATOR . $page_number;
             mkdir($page_level_output_dir);
 

--- a/src/writers/CsvNewspapers.php
+++ b/src/writers/CsvNewspapers.php
@@ -127,6 +127,9 @@ class CsvNewspapers extends Writer
             $pathinfo = pathinfo($page_path);
             $filename_segments = explode($this->page_sequence_separator, $pathinfo['filename']);
             $page_number = ltrim(end($filename_segments), '0');
+            if (strlen($page_number) === 0) {
+                $page_number = '0';
+            }
             $page_level_output_dir = $issue_level_output_dir . DIRECTORY_SEPARATOR . $page_number;
             mkdir($page_level_output_dir);
 


### PR DESCRIPTION
**Github issue**: #498

# What does this Pull Request do?

Allows the use of book and newspaper page files to end in all zeros (e.g. `page-00.tif`).

# What's new?

In the CsvBook and CsvNewspaper writers, tests to see if the page number is empty, which would result if the page number segment of a filename is comprised of all zeros. If it is, the page number variable is assigned a value of `0` in order to generate the correct directory name.

# How should this be tested?

This change must be smoke tested. There are no PHPUnit tests.

Using the data and configuration files in the attached zip file:

1. modify the issue_498_books.ini and issue_498_newspapers.ini configuration files to suit your system paths, etc.
1. in the master branch, run MIK on both .ini files. You should encounter errors starting with `"message":"mkdir(): File exists"` in your mik.log. Page directories for pages with all zeros in their filenames (`issue_498_books/book3/page-00.tif` and `issue_498_newspapers/1920-06-02/page-00.tif`) will not have been created in the output.
1. check out the issue-498 branch and rerun MIK on both config files. There should be no errors, and all the page directories should have been created.

# Additional Notes

* Does this change require documentation to be updated? 
Yes, we should document that using all zeros in filenames is OK.

* Does this change add any new dependencies? 
No

* Could this change impact execution of existing code?
Yes

# Interested parties

@bondjimbond 
[issue_498_test_data.zip](https://github.com/MarcusBarnes/mik/files/2889963/issue_498_test_data.zip)

