### PR TITLE
Oai-Pmh make directory if does not exist

### DIFF
--- a/src/writers/Oaipmh.php
+++ b/src/writers/Oaipmh.php
@@ -72,6 +72,14 @@ class Oaipmh extends Writer
 
         $normalized_record_id = $this->normalizeFilename($record_id);
         $metadata_file_path = $output_path . $normalized_record_id . '.xml';
+
+        $subdirectory = explode("/", $normalized_record_id);
+        $subdirectory_path = $output_path . $subdirectory[0];
+
+        if (!file_exists($subdirectory_path)) {
+          mkdir($subdirectory_path);
+        }
+
         $this->writeMetadataFile($metadata, $metadata_file_path, true);
 
         if ($this->metadata_only) {

--- a/src/writers/Oaipmh.php
+++ b/src/writers/Oaipmh.php
@@ -77,7 +77,7 @@ class Oaipmh extends Writer
         $subdirectory_path = $output_path . $subdirectory[0];
 
         if (!file_exists($subdirectory_path)) {
-          mkdir($subdirectory_path);
+            mkdir($subdirectory_path);
         }
 
         $this->writeMetadataFile($metadata, $metadata_file_path, true);


### PR DESCRIPTION
**Github issue**: (#503)

# What does this Pull Request do?

Checks if directory exists before creating the XML file. If it doesn't, create the directory first.

# What's new?

In some cases, the OAI endpoint will include a directory in the record ID representing the set. MIK fails if the directory does not already exist. Now we write it.

# How should this be tested?
Use the attached file (change txt to ini). Note failure to produce metadata until this branch is checked out. (The failure to produce the files is another issue.)
[mru_oai.txt](https://github.com/MarcusBarnes/mik/files/3340447/mru_oai.txt)

# Interested parties

@mjordan @MarcusBarnes 