### PR TITLE
Better oai

### DIFF
--- a/src/fetchers/Oaipmh.php
+++ b/src/fetchers/Oaipmh.php
@@ -77,7 +77,10 @@ class Oaipmh extends Fetcher
             $endpoint = new Endpoint($client);
             $records = $endpoint->listRecords($this->metadataPrefix, $this->from, $this->until, $this->setSpec);
             foreach ($records as $rec) {
-                $identifier = urlencode($rec->header->identifier);
+                $identifier = ($rec->header->identifier);
+                $identifier = json_decode(json_encode($identifier), 1)[0];
+                $identifier = urlencode(str_replace(':', '_', $identifier));
+
                 file_put_contents($this->tempDirectory . DIRECTORY_SEPARATOR . $identifier .
                     '.metadata', $rec->asXML());
                 // MIK expects each record to be an object with a ->key property.

--- a/src/fetchers/Oaipmh.php
+++ b/src/fetchers/Oaipmh.php
@@ -50,7 +50,7 @@ class Oaipmh extends Fetcher
         if (isset($settings['MANIPULATORS']['fetchermanipulators'])) {
             $this->fetchermanipulators = $settings['MANIPULATORS']['fetchermanipulators'];
         } else {
-            $this->fetchermanipulators = null;
+            $this->fetchermanipulators = array();
         }
 
         if (!$this->createTempDirectory()) {

--- a/src/writers/Oaipmh.php
+++ b/src/writers/Oaipmh.php
@@ -71,8 +71,8 @@ class Oaipmh extends Writer
         $output_path = $this->outputDirectory . DIRECTORY_SEPARATOR;
 
         $normalized_record_id = $this->normalizeFilename($record_id);
-        $metadata_file_path = $output_path . $normalized_record_id . '.xml';
-
+        $metadata_file_path = $output_path . urlencode($normalized_record_id) . '.xml';
+/*
         $subdirectory = explode("/", $normalized_record_id);
         $subdirectory_path = $output_path;
 
@@ -82,7 +82,7 @@ class Oaipmh extends Writer
                 mkdir($subdirectory_path);
             }
         }
-
+*/
         $this->writeMetadataFile($metadata, $metadata_file_path, true);
 
         if ($this->metadata_only) {


### PR DESCRIPTION
**Github issue**: (#508 )

# What does this Pull Request do?

In OAI-PMH fetcher, replaces `:` with `_` in the `$identifier` so that, when identifiers have colons in their names, they are converted to underscores when writing the temporary `.metadata` files instead of encoded nonsense. This makes the `.metadata` filenames match with the `$record_key` filenames used later on, and prevent errors (trying to look up `my_record_identifier.metadata` when the actual file is `my%3Arecord%3Aidentifier.metadata`). 

# Interested parties

@mjordan 
