### PR TITLE
Fix double escape in directory name

### DIFF
--- a/src/filegetters/CsvNewspapers.php
+++ b/src/filegetters/CsvNewspapers.php
@@ -155,7 +155,6 @@ class CsvNewspapers extends FileGetter
         $item_info = $this->fetcher->getItemInfo($record_key);
         $issue_directory = $item_info->{$this->file_name_field};
         $directory_regex = '#' . DIRECTORY_SEPARATOR . $issue_directory . DIRECTORY_SEPARATOR . '#';
-        $directory_regex = preg_quote($directory_regex);
         foreach ($this->OBJFilePaths as $paths) {
             foreach ($paths as $path) {
                 if (preg_match($directory_regex, $path)) {


### PR DESCRIPTION
Fixes #512 in which the dashes in the directory name are escaped twice

# What does this Pull Request do?

The removed `preg_quote` line escapes the dashes between dates in the directory name, but elsewhere the string is escaped a second time, resulting in two backslashes which causes MIK to fail.

# What's new?

Removing this line allows MIK to run properly.

# How should this be tested?

Set up a Newspaper CSV run using the files that are attached to the linked issue. Run MIK on the `.ini` file and view the errors. Run this branch and see success.

# Interested parties

@mjordan @MarcusBarnes 